### PR TITLE
For release 0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.4.6] - 2021-10-21
+- Projected transferred into radioactivedecay organization on GitHub: updated code & docs
+accordingly.
+- Moved hosting of docs to GitHub Pages (https://radioactivedecay.github.io).
+- Opened forum for project at https://github.com/radioactivedecay/radioactivedecay/discussions
+(uses GitHub Discussions).
+- Only store radioactivedecay version number in radioactivedecay/__init__.py file. Read this file
+to obtain version number in setup.py and docs/source/conf.py.
+
 ## [0.4.5] - 2021-10-15
 - Latest SymPy release (v1.9) changed internals of Rational / Matrix objects. This breaks loading
 of SymPy <=1.8 pickle objects when using SymPy v1.9. `radioactivedecay` now packages SymPy pickle

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Below are some general guidelines for requesting changes or submitting a PR.
 
 If you encounter an issue or find a bug in this package, please open an issue
 on the
-[GitHub issues page](https://github.com/alexmalins/radioactivedecay/issues).
+[GitHub issues page](https://github.com/radioactivedecay/radioactivedecay/issues).
 
 When submitting an issue please state the version of ``radioactivedecay`` that
 you are using, and include a minimal example of code or information which
@@ -20,7 +20,7 @@ demonstrates the problem.
 
 If you would like to contribute code, bug fixes or documentation improvements
 to the project, please fork the GitHub repository, make your changes, then
-submit a [pull request](https://github.com/alexmalins/radioactivedecay/pulls).
+submit a [pull request](https://github.com/radioactivedecay/radioactivedecay/pulls).
 
 Below are the code standards used by this project. Note they are not rigid
 requirements, but goals to aim for when submitting a PR. If you are not sure
@@ -66,7 +66,7 @@ The project uses Python's
 [unittest](https://docs.python.org/3/library/unittest.html) framework for
 testing. Please write unit tests for any new functionality you add. The
 tests are stored in the
-[tests](https://github.com/alexmalins/radioactivedecay/tree/main/tests)
+[tests](https://github.com/radioactivedecay/radioactivedecay/tree/main/tests)
 sub-directory.
 
 Run the tests by excecuting the command ``python -m unittest discover`` from
@@ -76,36 +76,36 @@ the base directory.
 ### Docstrings and Documentation
 
 Documentation is handled via the
-[README.md](https://github.com/alexmalins/radioactivedecay/blob/main/README.md)
+[README.md](https://github.com/radioactivedecay/radioactivedecay/blob/main/README.md)
 file and the reStructuredText files in the
-[docs/source](https://github.com/alexmalins/radioactivedecay/tree/main/docs/source/)
+[docs/source](https://github.com/radioactivedecay/radioactivedecay/tree/main/docs/source/)
 sub-directory. [Spinx](http://www.sphinx-doc.org/en/master/) is used for compiling the
 docs (run ``make html`` from within the
-[docs](https://github.com/alexmalins/radioactivedecay/tree/main/docs/)
+[docs](https://github.com/radioactivedecay/radioactivedecay/tree/main/docs/)
  sub-directory).
 
 Code docstrings follow the
 [NumPy format](https://numpydoc.readthedocs.io/en/latest/format.html). Please
 create new or update existing docstrings as appropriate. The doctrings are
 automatically harvested by Sphinx to create the API section of the
-[documentation](https://alexmalins.com/radioactivedecay/api.html).
+[documentation](https://radioactivedecay.github.io/api.html).
 
 
 ## Release Guidelines
 
 These notes describe the steps for cutting a new release:
 
-* Update the version number in setup.py
 * Update the version number in radioactivedecay/__init__.py
-* Update the version number in docs/source/conf.py
 * Make sure
-[CHANGELOG.md](https://github.com/alexmalins/radioactivedecay/blob/main/CHANGELOG.md)
+[CHANGELOG.md](https://github.com/radioactivedecay/radioactivedecay/blob/main/CHANGELOG.md)
 documents the changes
 * Run ``python setup.py sdist bdist_wheel`` to create a new package
 * Run the tests and code coverage calc: ``coverage run -m unittest discover``
 * Upload the code coverage reports to codecov
 * Compile the docs: ``docs/make html``
-* Upload the new docs html files to https://alexmalins.com/radioactivedecay/
+* Commit the new docs html files to the
+[docs repo](https://github.com/radioactivedecay/radioactivedecay.github.io)
+then push to GitHub
 * Create a release on GitHub (attach the ``.tar.gz`` and ``.whl`` distribution
 files)
 * Upload the new version to PyPi

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-﻿<img src="https://raw.githubusercontent.com/alexmalins/radioactivedecay/main/docs/source/images/radioactivedecay.png" alt="radioactivedecay logo" width="500"/>
+﻿<img src="https://raw.githubusercontent.com/radioactivedecay/radioactivedecay/main/docs/source/images/radioactivedecay.png" alt="radioactivedecay logo" width="500"/>
 
 ***
 
 [![PyPI](https://img.shields.io/pypi/v/radioactivedecay)](https://pypi.org/project/radioactivedecay/)
 [![Conda](https://img.shields.io/conda/v/conda-forge/radioactivedecay)](https://anaconda.org/conda-forge/radioactivedecay)
 [![Python Version](https://img.shields.io/pypi/pyversions/radioactivedecay)](https://pypi.org/project/radioactivedecay/)
-[![Latest Documentation](https://img.shields.io/badge/docs-latest-brightgreen)](https://alexmalins.com/radioactivedecay/)
+[![Latest Documentation](https://img.shields.io/badge/docs-latest-brightgreen)](https://radioactivedecay.github.io/)
 [![Test Coverage](https://codecov.io/gh/alexmalins/radioactivedecay/branch/master/graph/badge.svg)](https://codecov.io/gh/alexmalins/radioactivedecay)
 [![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
@@ -26,7 +26,7 @@ technicians and researchers who work with and study radioactivity, and for
 educational use.
 
 - **Full Documentation**: 
-[https://alexmalins.com/radioactivedecay](https://alexmalins.com/radioactivedecay/)
+[https://radioactivedecay.github.io/](https://radioactivedecay.github.io/)
 
 
 ## Installation
@@ -121,7 +121,7 @@ Use the ``plot()`` method to graph of the decay of an inventory over time:
 >>> mo99_t0.plot(20, 'd', yunits='Bq')
 ```
 
-<img src="https://raw.githubusercontent.com/alexmalins/radioactivedecay/main/docs/source/images/Mo-99_decay.png" alt="Mo-99 decay graph" width="450"/>
+<img src="https://raw.githubusercontent.com/radioactivedecay/radioactivedecay/main/docs/source/images/Mo-99_decay.png" alt="Mo-99 decay graph" width="450"/>
 
 The graph shows the decay of Mo-99 over 20 days, leading to the ingrowth of
 Tc-99m and a trace quantity of Tc-99. Graphs are drawn using Matplotlib.
@@ -170,7 +170,7 @@ diagrams:
 >>> nuc.plot()
 ```
 
-<img src="https://raw.githubusercontent.com/alexmalins/radioactivedecay/main/docs/source/images/Mo-99_chain.png" alt="Mo-99 decay chain" width="300"/>
+<img src="https://raw.githubusercontent.com/radioactivedecay/radioactivedecay/main/docs/source/images/Mo-99_chain.png" alt="Mo-99 decay chain" width="300"/>
 
 These diagrams are drawn using NetworkX and Matplotlib.
 
@@ -214,7 +214,7 @@ differential equations using linear algebra operations. It implements the
 method described in this paper:
 [M Amaku, PR Pascholati & VR Vanin, Comp. Phys. Comm. 181, 21-23
 (2010)](https://doi.org/10.1016/j.cpc.2009.08.011). See the
-[theory docpage](https://alexmalins.com/radioactivedecay/theory.html) for more
+[theory docpage](https://radioactivedecay.github.io/theory.html) for more
 details.
 
 It uses NumPy and SciPy routines for standard decay calculations
@@ -228,16 +228,16 @@ data from the [Atomic Mass Data Center](https://www-nds.iaea.org/amdc/)
 (AMDC - AME2020 and Nubase2020 evaluations).
 
 The [notebooks
-directory](https://github.com/alexmalins/radioactivedecay/tree/main/notebooks)
+directory](https://github.com/radioactivedecay/radioactivedecay/tree/main/notebooks)
 in the GitHub repository contains Jupyter Notebooks for creating the decay
 datasets that are read in by ``radioactivedecay``, e.g.
 [ICRP
-107](https://github.com/alexmalins/radioactivedecay/tree/main/notebooks/icrp107_dataset/icrp107_dataset.ipynb).
+107](https://github.com/radioactivedecay/radioactivedecay/tree/main/notebooks/icrp107_dataset/icrp107_dataset.ipynb).
 It also contains some comparisons against decay calculations made with
-[PyNE](https://github.com/alexmalins/radioactivedecay/tree/main/notebooks/comparisons/pyne/rd_pyne_truncated_compare.ipynb)
+[PyNE](https://github.com/radioactivedecay/radioactivedecay/tree/main/notebooks/comparisons/pyne/rd_pyne_truncated_compare.ipynb)
 and
 [Radiological
-Toolbox](https://github.com/alexmalins/radioactivedecay/tree/main/notebooks/comparisons/radiological_toolbox/radiological_toolbox_compare.ipynb).
+Toolbox](https://github.com/radioactivedecay/radioactivedecay/tree/main/notebooks/comparisons/radiological_toolbox/radiological_toolbox_compare.ipynb).
 
 
 ## Tests
@@ -252,19 +252,19 @@ $ python -m unittest discover
 ## License
 
 ``radioactivedecay`` is open source software released under the MIT License.
-See [LICENSE](https://github.com/alexmalins/radioactivedecay/blob/main/LICENSE)
+See [LICENSE](https://github.com/radioactivedecay/radioactivedecay/blob/main/LICENSE)
 file for details.
 
 The default decay data used by ``radioactivedecay`` (ICRP-107) is copyright
 2008 A. Endo and K.F. Eckerman and distributed under a separate
-[license](https://github.com/alexmalins/radioactivedecay/blob/main/LICENSE.ICRP-07).
+[license](https://github.com/radioactivedecay/radioactivedecay/blob/main/LICENSE.ICRP-07).
 The default atomic mass data is from AMDC
-([license](https://github.com/alexmalins/radioactivedecay/blob/main/LICENSE.AMDC)).
+([license](https://github.com/radioactivedecay/radioactivedecay/blob/main/LICENSE.AMDC)).
 
 
 ## Contributing
 
 Contributors are welcome to fix bugs, add new features or make feature 
 requests. Please open a pull request or a new issue on the
-[GitHub repository](https://github.com/alexmalins/radioactivedecay).
+[GitHub repository](https://github.com/radioactivedecay/radioactivedecay).
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,12 @@ copyright = "2021, JAEA"
 author = "Alex Malins"
 
 # The full version, including alpha/beta/rc tags
-release = "0.4.5"
+with open(f"../../{project}/__init__.py", "r") as file:
+    for line in file:
+        if line.startswith("__version__"):
+            version = line.strip().split()[-1][1:-1]
+            break
+release = version
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -35,7 +35,7 @@ Either command will attempt to install the dependencies (Matplotlib, NetworkX,
 NumPy, SciPy & SymPy) if they are not already present in the environment.
 
 It is also possible to clone the GitHub `repository 
-<https://github.com/alexmalins/radioactivedecay>`_ and install from within the
+<https://github.com/radioactivedecay/radioactivedecay>`_ and install from within the
 ``radioactivedecay`` directory using:
 
 .. code-block:: bash
@@ -47,11 +47,11 @@ Testing
 
 ``radioactivedecay`` includes code tests using the unittest framework. To run 
 the tests, first git clone the repository from `GitHub
-<https://github.com/alexmalins/radioactivedecay>`_:
+<https://github.com/radioactivedecay/radioactivedecay>`_:
 
 .. code-block:: bash
 
-    $ git clone https://github.com/alexmalins/radioactivedecay.git
+    $ git clone https://github.com/radioactivedecay/radioactivedecay.git
 
 then execute:
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -21,7 +21,7 @@ In order to use ``radioactivedecay``, you will need Python 3.6+ with the
 Matplotlib, NetworkX, NumPy, SciPy and SymPy packages installed. The code is
 platform independent and has been tested on Windows, MacOS and Linux systems.
 
-Quick Start
+Quick start
 -----------
 
 Install ``radioactivedecay`` using ``pip`` by:
@@ -110,20 +110,20 @@ How it works
 ``radioactivedecay`` calculates an analytical solution to the decay chain
 differential equations using matrix and vector multiplications. It implements
 the method described in ref. :ref:`[5] <refs>`.  See the
-`theory docpage <https://alexmalins.com/radioactivedecay/theory.html>`_ for
+:doc:`theory docpage <theory>` for
 more details. It calls NumPy :ref:`[6] <refs>` and SciPy :ref:`[7] <refs>` for
 the matrix operations. There is also a high numerical precision decay
 calculation mode based on SymPy :ref:`[8] <refs>` routines.
 
 The `notebooks directory 
-<https://github.com/alexmalins/radioactivedecay/tree/main/notebooks>`_ 
+<https://github.com/radioactivedecay/radioactivedecay/tree/main/notebooks>`_ 
 in the GitHub repository contains some Jupyter Notebooks for creating the 
 `ICRP-107 decay dataset
-<https://github.com/alexmalins/radioactivedecay/tree/main/notebooks/icrp107_dataset/icrp107_dataset.ipynb>`_
+<https://github.com/radioactivedecay/radioactivedecay/tree/main/notebooks/icrp107_dataset/icrp107_dataset.ipynb>`_
 for ``radioactivedecay``, and cross-checks against `PyNE
-<https://github.com/alexmalins/radioactivedecay/tree/main/notebooks/comparisons/pyne/rd_pyne_truncated_compare.ipynb>`_ 
+<https://github.com/radioactivedecay/radioactivedecay/tree/main/notebooks/comparisons/pyne/rd_pyne_truncated_compare.ipynb>`_ 
 :ref:`[9] <refs>` and `Radiological Toolbox 
-<https://github.com/alexmalins/radioactivedecay/tree/main/notebooks/comparisons/radiological_toolbox/radiological_toolbox_compare.ipynb>`_
+<https://github.com/radioactivedecay/radioactivedecay/tree/main/notebooks/comparisons/radiological_toolbox/radiological_toolbox_compare.ipynb>`_
 :ref:`[10] <refs>`.
 
 Limitations
@@ -167,18 +167,18 @@ License
 .. include:: <isonum.txt>
 
 ``radioactivedecay`` is open source software released under the `MIT 
-<https://github.com/alexmalins/radioactivedecay/blob/master/LICENSE>`_ licence.
+<https://github.com/radioactivedecay/radioactivedecay/blob/master/LICENSE>`_ licence.
 
 The default decay data used by ``radioactivedecay`` is ICRP-107 :ref:`[1] <refs>`, which
 is Copyright |copy| A. Endo and K.F. Eckerman (2008). See `LICENSE.ICRP-07
-<https://github.com/alexmalins/radioactivedecay/blob/master/LICENSE.ICRP-07>`_
+<https://github.com/radioactivedecay/radioactivedecay/blob/master/LICENSE.ICRP-07>`_
 for more details.
 
 The default atomic mass data is based on the Atomic Mass Data Center (`AMDC
 <https://www-nds.iaea.org/amdc/>`_) AME2020 :ref:`[2] <refs>`,
 :ref:`[3] <refs>` and Nubase2020 :ref:`[4] <refs>` evaluations. See
 `LICENSE.AMDC
-<https://github.com/alexmalins/radioactivedecay/blob/master/LICENSE.AMDC>`_ for
+<https://github.com/radioactivedecay/radioactivedecay/blob/master/LICENSE.AMDC>`_ for
 more details.
 
 Contributors
@@ -195,17 +195,15 @@ Contributing
 
 Users are welcome to fix bugs, add new features or make feature requests.
 Please read the `contributor guidelines
-<https://github.com/alexmalins/radioactivedecay/blob/master/CONTRIBUTING.md>`_
+<https://github.com/radioactivedecay/radioactivedecay/blob/master/CONTRIBUTING.md>`_
 and open a pull request or issue on the
-`GitHub repository <https://github.com/alexmalins/radioactivedecay>`_.
+`GitHub repository <https://github.com/radioactivedecay/radioactivedecay>`_.
 
-Queries
--------
+Queries and suggestions
+-----------------------
 
-If you have any questions or queries about the functionality and use of this
-package, you are welcome to `email
-<mailto:radioactivedecay@REMOVETHISalexmalins.com>`_ the lead contributor
-(Alex Malins) for support.
+If you have any questions or suggestions, please post on the `Discussions page
+on GitHub <https://github.com/radioactivedecay/radioactivedecay/discussions>`_.
 
 Acknowledgements
 ----------------

--- a/docs/source/theory.rst
+++ b/docs/source/theory.rst
@@ -98,7 +98,7 @@ As matrices :math:`C` and :math:`C^{-1}` are independent of time, they can be
 pre-calculated and imported into ``radioactivedecay`` as part of a radioactive
 decay dataset.  :math:`C` and :math:`C^{-1}`  are pre-calculated for the
 ICRP-107 :ref:`[2] <refs>` dataset in
-`this Jupter notebook <https://github.com/alexmalins/radioactivedecay/notebooks/tree/main/icrp107_dataset/icrp107_dataset.ipynb>`_
+`this Jupter notebook <https://github.com/radioactivedecay/radioactivedecay/notebooks/tree/main/icrp107_dataset/icrp107_dataset.ipynb>`_
 held in the GitHub repository.
 
 Note that :math:`C`, :math:`C^{-1}` and :math:`e^{\varLambda_{d} t}` are sparse

--- a/radioactivedecay/__init__.py
+++ b/radioactivedecay/__init__.py
@@ -16,7 +16,7 @@ technicians and researchers who work with and study radioactivity, and for
 educational use.
 """
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 
 from radioactivedecay.decaydata import DecayData, DEFAULTDATA
 from radioactivedecay.inventory import Inventory, InventoryHP

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,31 @@
 import setuptools
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
+project = "radioactivedecay"
+
+with open(f"{project}/__init__.py", "r") as file:
+    for line in file:
+        if line.startswith("__version__"):
+            version = line.strip().split()[-1][1:-1]
+            break
+
+with open("README.md", "r") as file:
+    long_description = file.read()
 
 setuptools.setup(
-    name="radioactivedecay",
-    version="0.4.5",
+    name=project,
+    version=version,
     author="Alex Malins",
     author_email="radioactivedecay@REMOVETHISalexmalins.com",
     license="MIT, ICRP-07, AMDC",
     description="A Python package for radioactive decay modelling that supports 1252 radionuclides, decay chains, branching, and metastable states.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/alexmalins/radioactivedecay",
+    url="https://github.com/radioactivedecay/radioactivedecay",
     project_urls={
-        "Bug Tracker": "https://github.com/alexmalins/radioactivedecay/issues",
-        "Documentation": "https://alexmalins.com/radioactivedecay",
-        "Source Code": "https://github.com/alexmalins/radioactivedecay",
+        "Bug Tracker": "https://github.com/radioactivedecay/radioactivedecay/issues",
+        "Discussions": "https://github.com/radioactivedecay/radioactivedecay/discussions",
+        "Documentation": "https://radioactivedecay.github.io",
+        "Source Code": "https://github.com/radioactivedecay/radioactivedecay",
     },
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
- Projected transferred into radioactivedecay organization on GitHub: updated code & docs
accordingly.
- Moved hosting of docs to GitHub Pages (https://radioactivedecay.github.io).
- Opened forum for project at https://github.com/radioactivedecay/radioactivedecay/discussions
(uses GitHub Discussions).
- Only store radioactivedecay version number in radioactivedecay/__init__.py file. Read this file
to obtain version number in setup.py and docs/source/conf.py.