### PR TITLE
fix old refs to Radionuclide class, small rewrites in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.7] - 2021-11-08
+- Fix old references to `Radionuclide` class in Readme, docs and docstrings (#54 & #55). This class
+was renamed to `Nuclide` from release v0.4.0.
+- Other small rewrites to docs.
+
 ## [0.4.6] - 2021-10-21
 - Projected transferred into radioactivedecay organization on GitHub: updated code & docs
 accordingly.

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -85,12 +85,12 @@ Use the ``plot()`` method to show the decay of the inventory over time:
 
 The graph shows the decay of H-3 over a 100 year period.
 
-Use the ``Radionuclide`` class to fetch decay data about a particular
-radionuclide and to draw diagrams of its decay chain:
+Use the ``Nuclide`` class to fetch decay data about a particular radionuclide
+and to draw diagrams of its decay chain:
 
 .. code-block:: python3
 
-    >>> nuc = rd.Radionuclide('H-3')
+    >>> nuc = rd.Nuclide('H-3')
     >>> nuc.half_life('readable')
     '12.32 y'
     >>> nuc.progeny()

--- a/docs/source/plotting.rst
+++ b/docs/source/plotting.rst
@@ -4,13 +4,13 @@ Plotting
 Decay chain diagrams
 --------------------
 
-Use the ``Radionuclide`` class ``plot()`` method to create a diagram of the
+Use the ``Nuclide`` class ``plot()`` method to create a diagram of the
 decay chain originating from a radionuclide:
 
 .. code-block:: python3
 
     >>> import radioactivedecay as rd
-    >>> nuc = rd.Radionuclide('Mo-99')
+    >>> nuc = rd.Nuclide('Mo-99')
     >>> fig, ax = nuc.plot()
 
 .. image:: images/Mo-99_chain.png
@@ -27,7 +27,7 @@ default value of 0.5:
 .. code-block:: python3
 
     >>> import radioactivedecay as rd
-    >>> nuc = rd.Radionuclide('Rn-22')
+    >>> nuc = rd.Nuclide('Rn-222')
     >>> fig, ax = nuc.plot(label_pos=0.66)
 
 .. image:: images/Rn-222_chain.png
@@ -37,7 +37,7 @@ Inventory decay graphs
 ----------------------
 
 The ``Inventory`` and ``InventoryHP`` class  ``plot()`` method is for creating
-graphs of the radioactive decay of the radionuclides in an inventory and their
+graphs of the radioactive decay of the nuclides in an inventory and their
 progeny over time. At its simplest, supply the decay timespan to the method:
 
 .. code-block:: python3
@@ -61,8 +61,8 @@ graph to your own needs:
   
 Now we can see the long-lived Pb-210 radionuclide and its progeny, which form
 over a period of months. Large numbers of curves can make the graphs difficult
-to read. Use the ``display`` parameter to specify only the radionuclides you
-want to display. The curves follow the same order as the list you supply:
+to read. Use the ``display`` parameter to specify only the nuclides you wish to
+display. The curves follow the same order as the list you supply:
 
 .. code-block:: python3
 
@@ -71,9 +71,9 @@ want to display. The curves follow the same order as the list you supply:
 .. image:: images/Rn-222_decay_3.png
   :width: 450
 
-By default radionuclides are plotted according to those highest in the decay
-chains downwards. If you wish to display radionuclides in alphabetical order,
-use the ``order`` parameter:
+By default nuclides are plotted according to those highest in the decay chains
+downwards. If you wish to display nuclides in alphabetical order, use the
+``order`` parameter:
 
 .. code-block:: python3
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -10,22 +10,22 @@ Import the ``radioactivedecay`` package by:
 
     >>> import radioactivedecay as rd
 
-Creating inventories of radionuclides
--------------------------------------
+Creating inventories of nuclides
+--------------------------------
 
-Create an inventory of radionuclides and associated activities as follows:
+Create an inventory of nuclides as follows:
 
 .. code-block:: python3
 
     >>> inv_t0 = rd.Inventory({'U-238': 99.274, 'U-235': 0.720, 'U-234': 0.005}, 'mol')
 
-This is an inventory of natural uranium.
+This is an inventory of natural uranium. The amounts of each nuclide were
+specified in moles.
 
-The ``Inventory`` class keeps track of the number of atoms
-of each nuclide. The following commands can be used to convert the contents
-(the nuclides and their respective number of atoms) into activities, numbers,
-masses, or abundances, as well as return the decay data set associated with an
-inventory:
+Within the code, the ``Inventory`` class keeps track of the number of atoms of
+each nuclide it contains. The following commands can be used to show the
+contents in terms of activities, numbers of atoms, moles, masses, or
+abundances:
 
 .. code-block:: python3
 
@@ -46,8 +46,8 @@ inventory:
     >>> inv_t0
     Inventory activities (Bq): {'U-234': 269401605.0086039, 'U-235': 13528246.506057048, 'U-238': 293903005.67125}, decay dataset: icrp107_ame2020_nubase2020
 
-By default the input dictionary to ``Inventory()`` is assumed to contain
-activities in Bq. The user can easily specify different units:
+By default the dictionary passed to the ``Inventory()`` constructor is assumed
+to contain activities in Bq. The user can easily specify different units:
 
 .. code-block:: python3
 
@@ -186,8 +186,8 @@ the next three digits are its atomic mass number, and the last four are for
 specifing its metastability. For nuclides with atomic mass numbers less than 100,
 zeroes must be included as placeholders (ex. aaa = 003 for H-3). 
 
-Metastable states of radionuclides can be inputted by appending \'m\', \'n\',
-etc. to the nuclide string, or 0001, 0002, etc. to the id, for first, second...
+Metastable states of nuclides can be inputted by appending \'m\', \'n\', etc.
+to the nuclide string, or 0001, 0002, etc. to the id, for first, second...
 metastable states, respectively:
 
 .. code-block:: python3
@@ -319,10 +319,10 @@ data in ICRP-107, which is the default dataset in ``radioactivedecay``, by:
     'β-'
 
 
-Adding and removing radionuclides from inventories
---------------------------------------------------
+Adding and removing nuclides from inventories
+---------------------------------------------
 
-It is easy to add radionuclides to an ``Inventory`` using the ``add()`` method:
+It is easy to add nuclides to an ``Inventory`` using the ``add()`` method:
 
 .. code-block:: python3
 
@@ -333,8 +333,8 @@ It is easy to add radionuclides to an ``Inventory`` using the ``add()`` method:
     >>> inv.activities()
     {'Be-10': 2.0, 'C-14': 3.0, 'H-3': 1.0, 'K-40': 4.0}
 
-Similarly, subtract radionuclides from an ``Inventory`` using the
-``subtract()`` method:
+Similarly, subtract nuclides from an ``Inventory`` using the ``subtract()``
+method:
 
 .. code-block:: python3
 
@@ -342,8 +342,7 @@ Similarly, subtract radionuclides from an ``Inventory`` using the
     >>> inv.activities()
     {'Be-10': 1.0, 'C-14': 3.0, 'H-3': 1.0, 'K-40': 2.0}
 
-Likewise use ``remove()`` to erase one or more radionuclide from an
-``Inventory``:
+Likewise use ``remove()`` to erase one or more nuclide from an ``Inventory``:
 
 .. code-block:: python3
 
@@ -366,16 +365,16 @@ for inputs other than activities, and mixing input types is allowed:
     >>> inv.activities()
     {'C-14': 1.8233790683016682, 'H-3': 2.3177330463306007}
 
-You can also supply ``Radionuclide`` objects instead of strings to the
+You can also supply ``Nuclide`` objects instead of strings to the
 ``Inventory`` constructor, and the ``add()`` and ``remove()`` methods:
 
 .. code-block:: python3
 
-    >>> H3 = rd.Radionuclide('H-3')
+    >>> H3 = rd.Nuclide('H-3')
     >>> inv = rd.Inventory({H3: 1.0})
     >>> inv.activities()
     {'H-3': 1.0}
-    >>> Be10 = rd.Radionuclide('Be-10')
+    >>> Be10 = rd.Nuclide('Be-10')
     >>> inv.add({Be10: 2.0})
     >>> inv.activities()
     {'Be-10': 2.0, 'H-3': 1.0}
@@ -383,9 +382,9 @@ You can also supply ``Radionuclide`` objects instead of strings to the
     >>> inv.activities()
     {'Be-10': 2.0}
 
-Note if the decay dataset of the ``Radionuclide`` instance is different to that
-of the ``Inventory`` instance, the former will be ignored and the existing
-decay dataset of the ``Inventory`` will be used instead.
+Note if the decay dataset of the ``Nuclide`` instance is different to that of
+the ``Inventory`` instance, the former will be ignored and the existing decay
+dataset of the ``Inventory`` will be used instead.
 
 Inventory arithmetic
 --------------------
@@ -412,8 +411,8 @@ It is also possible to subtract the contents of one inventory from another:
 Multiplication and division on inventories
 ------------------------------------------
 
-You can multiply or divide the activities of all radionuclides in an inventory
-by a constant as follows:
+You can multiply or divide the amounts of all nuclides in an inventory by a
+constant as follows:
 
 .. code-block:: python3
 

--- a/radioactivedecay/__init__.py
+++ b/radioactivedecay/__init__.py
@@ -16,7 +16,7 @@ technicians and researchers who work with and study radioactivity, and for
 educational use.
 """
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"
 
 from radioactivedecay.decaydata import DecayData, DEFAULTDATA
 from radioactivedecay.inventory import Inventory, InventoryHP

--- a/radioactivedecay/nuclide.py
+++ b/radioactivedecay/nuclide.py
@@ -116,7 +116,7 @@ class Nuclide:
 
     def __eq__(self, other: object) -> bool:
         """
-        Check whether two ``Radionuclide`` instances are equal with ``==`` operator.
+        Check whether two ``Nuclide`` instances are equal with ``==`` operator.
         """
 
         if not isinstance(other, Nuclide):
@@ -125,7 +125,7 @@ class Nuclide:
 
     def __ne__(self, other: object) -> bool:
         """
-        Check whether two ``Radionuclide`` instances are not equal with ``!=`` operator.
+        Check whether two ``Nuclide`` instances are not equal with ``!=`` operator.
         """
 
         if not isinstance(other, Nuclide):
@@ -134,7 +134,7 @@ class Nuclide:
 
     def __hash__(self) -> int:
         """
-        Hash function for ``Radionuclide`` instances.
+        Hash function for ``Nuclide`` instances.
         """
 
         return hash((self.nuclide, self.decay_data.dataset_name))
@@ -156,7 +156,7 @@ class Nuclide:
         Returns
         -------
         float or str
-            Radionuclide half-life.
+            Half-life of the nuclide.
 
         Examples
         --------
@@ -343,8 +343,8 @@ def _build_decay_digraph(
 
     Parameters
     ----------
-    parent : Radionuclide
-        Radionuclide instance of the parent nuclide of the decay chain.
+    parent : Nuclide
+        Nuclide instance of the parent nuclide of the decay chain.
     digraph : networkx.classes.digraph.DiGraph
         DiGraph for the decay chain.
 


### PR DESCRIPTION
For release 0.4.7:

- Fix old references to `Radionuclide` class in Readme, docs and docstrings (#54 & #55). This class
was renamed to `Nuclide` from release v0.4.0.
- Other small rewrites to docs.