### PR TITLE
Fix codecov badge in readme for new GitHub organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Conda](https://img.shields.io/conda/v/conda-forge/radioactivedecay)](https://anaconda.org/conda-forge/radioactivedecay)
 [![Python Version](https://img.shields.io/pypi/pyversions/radioactivedecay)](https://pypi.org/project/radioactivedecay/)
 [![Latest Documentation](https://img.shields.io/badge/docs-latest-brightgreen)](https://radioactivedecay.github.io/)
-[![Test Coverage](https://codecov.io/gh/alexmalins/radioactivedecay/branch/master/graph/badge.svg)](https://codecov.io/gh/alexmalins/radioactivedecay)
+[![Test Coverage](https://codecov.io/gh/radioactivedecay/radioactivedecay/branch/master/graph/badge.svg)](https://codecov.io/gh/radioactivedecay/radioactivedecay)
 [![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 ``radioactivedecay`` is a Python package for radioactive decay calculations.


### PR DESCRIPTION
Update the Covecov badge and link in line with the move to the radioactivedecay GitHub organization.