### PR TITLE
Refactor converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
 ## [0.X.X] - 20XX-XX-XX
-- Move dataset creation and comparison notebooks to separate repos within the
-radioactivedecay org on GitHub (#63).
+- Code refactoring: reduce coupling between modules by refactoring Converter & Nuclide classes to
+not store duplicate data, but to receive needed data only via their API calls. DecayData objects no
+longer need to store Converter objects. Continuing to reduce pylint/mypy errors/warnings, however
+will need to wait to bump requirement to Python 3.7+ to improve type hinting of NumPy/SciPy arrays
+(requires NumPy 1.21+, holding off for now to maintain Python 3.6 support) (#64).
+- Move dataset creation and comparison notebooks to separate repos within the radioactivedecay org
+on GitHub (#63).
 - Tweak GitHub Issue & PR markdown templates (#62).
 
 ## [0.4.8] - 2021-12-13

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ results for decay chains containing radionuclides with orders of magnitude
 differences between the half-lives.
 
 This is free-to-use open source software. It was created for engineers,
-technicians and researchers who work with and study radioactivity, and for
+technicians and researchers who work with radioactivity, and for
 educational use.
 
 - **Full Documentation**: 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,7 +22,7 @@ results for decay chains containing radionuclides with orders of magnitude
 differences between the half-lives.
 
 This is free-to-use open source software. It was created for engineers,
-technicians and researchers who work with and study radioactivity, and for
+technicians and researchers who work with radioactivity, and for
 educational use.
 
 .. toctree::

--- a/radioactivedecay/__init__.py
+++ b/radioactivedecay/__init__.py
@@ -12,7 +12,7 @@ results for decay chains containing radionuclides with orders of magnitude
 differences between the half-lives.
 
 This is free-to-use open source software. It was created for engineers,
-technicians and researchers who work with and study radioactivity, and for
+technicians and researchers who work with radioactivity, and for
 educational use.
 
 The docstring code examples assume the ``radioactivedecay`` package has been

--- a/radioactivedecay/converters.py
+++ b/radioactivedecay/converters.py
@@ -42,24 +42,24 @@ class UnitConverter(ABC):
 
     @property
     @abstractmethod
-    def time_units(self):
+    def time_units(self) -> Dict[str, Union[float, Expr]]:
         pass
 
     year_units = {"y", "yr", "year", "years", "ky", "My", "By", "Gy", "Ty", "Py"}
 
     @property
     @abstractmethod
-    def activity_units(self):
+    def activity_units(self) -> Dict[str, Union[float, Expr]]:
         pass
 
     @property
     @abstractmethod
-    def mass_units(self):
+    def mass_units(self) -> Dict[str, Union[float, Expr]]:
         pass
 
     @property
     @abstractmethod
-    def mole_units(self):
+    def mole_units(self) -> Dict[str, Union[float, Expr]]:
         pass
 
     @classmethod
@@ -429,7 +429,7 @@ class QuantityConverter(ABC):
 
     @property
     @abstractmethod
-    def time_units(self):
+    def avogadro(self) -> Union[float, Expr]:
         pass
 
     @staticmethod

--- a/radioactivedecay/converters.py
+++ b/radioactivedecay/converters.py
@@ -11,7 +11,7 @@ as `rd`:
 
 """
 
-from abc import ABC, abstractmethod
+from abc import ABC
 from typing import Dict, Union
 from sympy import Integer, nsimplify
 from sympy.core.expr import Expr
@@ -28,48 +28,22 @@ class UnitConverter(ABC):
     ----------
     time_units : dict
         Dictionary containing numbers of each time unit per second.
-    year_units : set
-        Set containing all year units.
     activity_units : dict
         Dictionary containing amounts of each activity unit per Bq.
     mass_units : dict
         Dictionary containing amounts of each mass unit per g.
     moles_units : dict
         Dictionary containing amounts of each mole unit per mol.
+    year_units : set
+        Set containing all year units. Used to pick up where days in year conversion is needed.
 
     """
 
-    @property
-    @abstractmethod
-    def time_units(self) -> Dict[str, Union[float, Expr]]:
-        """
-        Returns dictionary containing numbers of each time unit per second.
-        Note: year units do not contain days in year conversion.
-        """
-
+    time_units: Dict[str, Union[float, Expr]]
+    activity_units: Dict[str, Union[float, Expr]]
+    mass_units: Dict[str, Union[float, Expr]]
+    moles_units: Dict[str, Union[float, Expr]]
     year_units = {"y", "yr", "year", "years", "ky", "My", "By", "Gy", "Ty", "Py"}
-    """Set containing year units. Used to pick up where days in year conversion is needed."""
-
-    @property
-    @abstractmethod
-    def activity_units(self) -> Dict[str, Union[float, Expr]]:
-        """
-        Dictionary containing amounts of each activity unit per Bq.
-        """
-
-    @property
-    @abstractmethod
-    def mass_units(self) -> Dict[str, Union[float, Expr]]:
-        """
-        Dictionary containing amounts of each mass unit per g.
-        """
-
-    @property
-    @abstractmethod
-    def moles_units(self) -> Dict[str, Union[float, Expr]]:
-        """
-        Dictionary containing amounts of each mole unit per mol.
-        """
 
     @classmethod
     def time_unit_conv(
@@ -438,12 +412,7 @@ class QuantityConverter(ABC):
 
     """
 
-    @property
-    @abstractmethod
-    def avogadro(self) -> Union[float, Expr]:
-        """
-        Avogadro constant (number of atoms/mol).
-        """
+    avogadro: Union[float, Expr]
 
     @staticmethod
     def activity_to_number(

--- a/radioactivedecay/converters.py
+++ b/radioactivedecay/converters.py
@@ -43,24 +43,34 @@ class UnitConverter(ABC):
     @property
     @abstractmethod
     def time_units(self) -> Dict[str, Union[float, Expr]]:
-        pass
+        """
+        Returns dictionary containing numbers of each time unit per second.
+        Note: year units do not contain days in year conversion.
+        """
 
     year_units = {"y", "yr", "year", "years", "ky", "My", "By", "Gy", "Ty", "Py"}
+    """Set containing year units. Used to pick up where days in year conversion is needed."""
 
     @property
     @abstractmethod
     def activity_units(self) -> Dict[str, Union[float, Expr]]:
-        pass
+        """
+        Dictionary containing amounts of each activity unit per Bq.
+        """
 
     @property
     @abstractmethod
     def mass_units(self) -> Dict[str, Union[float, Expr]]:
-        pass
+        """
+        Dictionary containing amounts of each mass unit per g.
+        """
 
     @property
     @abstractmethod
     def mole_units(self) -> Dict[str, Union[float, Expr]]:
-        pass
+        """
+        Dictionary containing amounts of each mole unit per mol.
+        """
 
     @classmethod
     def time_unit_conv(
@@ -430,7 +440,9 @@ class QuantityConverter(ABC):
     @property
     @abstractmethod
     def avogadro(self) -> Union[float, Expr]:
-        pass
+        """
+        Avogadro constant (number of atoms/mol).
+        """
 
     @staticmethod
     def activity_to_number(

--- a/radioactivedecay/converters.py
+++ b/radioactivedecay/converters.py
@@ -13,8 +13,7 @@ as `rd`:
 
 from abc import ABC, abstractmethod
 from typing import Dict, Union
-import numpy as np
-from sympy import Integer, Matrix, nsimplify, Rational
+from sympy import Integer, nsimplify
 from sympy.core.expr import Expr
 
 AVOGADRO = 6.02214076e23
@@ -67,14 +66,18 @@ class UnitConverter(ABC):
 
     @property
     @abstractmethod
-    def mole_units(self) -> Dict[str, Union[float, Expr]]:
+    def moles_units(self) -> Dict[str, Union[float, Expr]]:
         """
         Dictionary containing amounts of each mole unit per mol.
         """
 
     @classmethod
     def time_unit_conv(
-        cls, time_period: Union[float, Expr], units_from: str, units_to: str, year_conv: Union[float, Expr]
+        cls,
+        time_period: Union[float, Expr],
+        units_from: str,
+        units_to: str,
+        year_conv: Union[float, Expr],
     ) -> Union[float, Expr]:
         """
         Converts a time period from one time unit to another.
@@ -158,9 +161,7 @@ class UnitConverter(ABC):
                 str(units_to) + ' is not a activitiy unit, e.g. "Bq", "kBq", "Ci"...'
             )
 
-        return (
-            activity * cls.activity_units[units_from] / cls.activity_units[units_to]
-        )
+        return activity * cls.activity_units[units_from] / cls.activity_units[units_to]
 
     @classmethod
     def mass_unit_conv(
@@ -246,7 +247,7 @@ class UnitConverterFloat(UnitConverter):
     Unit converter using floats.
     """
 
-    time_units = {
+    time_units: Dict[str, float] = {
         "ps": 1.0e-12,
         "ns": 1.0e-9,
         "μs": 1.0e-6,
@@ -276,7 +277,7 @@ class UnitConverterFloat(UnitConverter):
         "Py": 86400.0 * 1.0e15,
     }
 
-    activity_units = {
+    activity_units: Dict[str, float] = {
         "pBq": 1.0e-12,
         "nBq": 1.0e-9,
         "μBq": 1.0e-6,
@@ -304,7 +305,7 @@ class UnitConverterFloat(UnitConverter):
         "dpm": 60.0,
     }
 
-    mass_units = {
+    mass_units: Dict[str, float] = {
         "pg": 1.0e-12,
         "ng": 1.0e-9,
         "μg": 1.0e-6,
@@ -317,7 +318,7 @@ class UnitConverterFloat(UnitConverter):
         "ton": 1.0e6,
     }
 
-    moles_units = {
+    moles_units: Dict[str, float] = {
         "pmol": 1.0e-12,
         "nmol": 1.0e-9,
         "μmol": 1.0e-6,
@@ -338,7 +339,7 @@ class UnitConverterSympy(UnitConverter):
     Unit converter using SymPy arbitrary precision operations.
     """
 
-    time_units = {
+    time_units: Dict[str, Expr] = {
         "ps": Integer(1) / 1000000000000,
         "ns": Integer(1) / 1000000000,
         "μs": Integer(1) / 1000000,
@@ -368,7 +369,7 @@ class UnitConverterSympy(UnitConverter):
         "Py": Integer(86400) * 1000000000000000,
     }
 
-    activity_units = {
+    activity_units: Dict[str, Expr] = {
         "pBq": Integer(1) / 1000000000000,
         "nBq": Integer(1) / 1000000000,
         "μBq": Integer(1) / 1000000,
@@ -396,7 +397,7 @@ class UnitConverterSympy(UnitConverter):
         "dpm": Integer(60),
     }
 
-    mass_units = {
+    mass_units: Dict[str, Expr] = {
         "pg": Integer(1) / 1000000000000,
         "ng": Integer(1) / 1000000000,
         "μg": Integer(1) / 1000000,
@@ -409,7 +410,7 @@ class UnitConverterSympy(UnitConverter):
         "ton": Integer(1000000),
     }
 
-    moles_units= {
+    moles_units: Dict[str, Expr] = {
         "pmol": Integer(1) / 1000000000000,
         "nmol": Integer(1) / 1000000000,
         "μmol": Integer(1) / 1000000,
@@ -446,7 +447,7 @@ class QuantityConverter(ABC):
 
     @staticmethod
     def activity_to_number(
-       activity: Union[float, Expr], decay_const: Union[float, Expr]
+        activity: Union[float, Expr], decay_const: Union[float, Expr]
     ) -> Union[float, Expr]:
         """
         Converts an activity in Bq to the number of atoms.
@@ -574,12 +575,13 @@ class QuantityConverter(ABC):
 
         return number / cls.avogadro
 
+
 class QuantityConverterFloat(QuantityConverter):
     """
     Quantity converter using SymPy arbitrary precision operations.
     """
 
-    avogadro = AVOGADRO
+    avogadro: float = AVOGADRO
 
     @classmethod
     def __repr__(cls) -> str:
@@ -591,7 +593,7 @@ class QuantityConverterSympy(QuantityConverter):
     Quantity converter using SymPy arbitrary precision operations.
     """
 
-    avogadro = nsimplify(AVOGADRO)
+    avogadro: Expr = nsimplify(AVOGADRO)
 
     @classmethod
     def __repr__(cls) -> str:

--- a/radioactivedecay/decaydata.py
+++ b/radioactivedecay/decaydata.py
@@ -406,7 +406,7 @@ class DecayData:
                 half_life,
                 units_from=unit,
                 units_to=units,
-                year_conv=self.float_year_conv
+                year_conv=self.float_year_conv,
             )
         )
 
@@ -650,7 +650,9 @@ def load_dataset(
     decay_consts = np.array(
         [
             np.log(2)
-            / UnitConverterFloat.time_unit_conv(hl[0], units_from=hl[1], units_to="s", year_conv=data["year_conv"])
+            / UnitConverterFloat.time_unit_conv(
+                hl[0], units_from=hl[1], units_to="s", year_conv=data["year_conv"]
+            )
             for hl in data["hldata"]
         ]
     )

--- a/radioactivedecay/decaydata.py
+++ b/radioactivedecay/decaydata.py
@@ -268,7 +268,8 @@ class DecayMatricesSympy(DecayMatrices):
 class DecayData:
     """
     Instances of DecayData store a complete radioactive decay dataset. It stores data for decay
-    calculations using DecayMatrices.
+    calculations and inventory transformations using DecayMatrices attributes. Other decay data
+    which are reported to users but not used incalculations are stored in other instance
     attributes.
 
     Parameters

--- a/radioactivedecay/decaydata.py
+++ b/radioactivedecay/decaydata.py
@@ -30,12 +30,7 @@ import sympy
 from sympy import Matrix
 from sympy.matrices import SparseMatrix
 from sympy.core.expr import Expr
-from radioactivedecay.converters import (
-    UnitConverterFloat,
-    UnitConverterSympy,
-    QuantityConverter,
-    QuantityConverterSympy,
-)
+from radioactivedecay.converters import UnitConverterFloat
 from radioactivedecay.utils import parse_nuclide
 
 try:
@@ -273,9 +268,7 @@ class DecayMatricesSympy(DecayMatrices):
 class DecayData:
     """
     Instances of DecayData store a complete radioactive decay dataset. It stores data for decay
-    calculations, inventory transformations and quantity conversions using DecayMatrices,
-    QuantityConverter, DecayMatricesSympy, and QuantityConverterSympy objects. Other decay data
-    which are reported to users but not used in calculations are stored in other instance
+    calculations using DecayMatrices.
     attributes.
 
     Parameters
@@ -309,8 +302,6 @@ class DecayData:
         NumPy array of lists with branching fraction data.
     dataset_name : str
         Name of the decay dataset.
-    float_quantity_converter : QuantityConverter
-        Convert between quantities using floating point operations.
     float_year_conv : float
         Number of days in one year for float time unit conversions.
     hldata : numpy.ndarray
@@ -329,8 +320,6 @@ class DecayData:
     sympy_data : None or DecayMatricesSympy
         Dataset of arbitrary-precision decay matrices (SymPy objects). Or None if this functionality
         is not used.
-    sympy_quantity_converter : None or QuantityConverterSympy
-        Convert between quantities using SymPy arbitrary precision operations.
     sympy_year_conv : None or Expr
         Number of days in one year for SymPy time unit conversions.
 
@@ -360,23 +349,11 @@ class DecayData:
         self.progeny = progeny
         self.scipy_data = scipy_data
 
-        self.float_quantity_converter = QuantityConverter(
-            self.nuclide_dict,
-            self.scipy_data.atomic_masses,
-            self.scipy_data.decay_consts,
-        )
-
         self.sympy_data: Optional[DecayMatricesSympy] = None
-        self.sympy_quantity_converter: Optional[QuantityConverterSympy] = None
         self.sympy_year_conv: Optional[Expr] = None
 
         if sympy_data and sympy_year_conv:
             self.sympy_data = sympy_data
-            self.sympy_quantity_converter = QuantityConverterSympy(
-                self.nuclide_dict,
-                self.sympy_data.atomic_masses,
-                self.sympy_data.decay_consts,
-            )
             self.sympy_year_conv = sympy_year_conv
 
     def half_life(self, nuclide: str, units: str = "s") -> Union[float, str]:

--- a/radioactivedecay/inventory.py
+++ b/radioactivedecay/inventory.py
@@ -122,9 +122,7 @@ class Inventory:
         else:
             contents_with_parsed_keys = contents
         contents_sorted = sort_dictionary_alphabetically(contents_with_parsed_keys)
-        self.contents = self._convert_to_number(
-            contents_sorted, units
-        )
+        self.contents = self._convert_to_number(contents_sorted, units)
 
     @staticmethod
     def _parse_nuclides(
@@ -171,12 +169,14 @@ class Inventory:
 
         return self.decay_data.scipy_data
 
-    def _get_quantity_converter(self) -> QuantityConverterFloat:
+    @staticmethod
+    def _get_quantity_converter() -> QuantityConverterFloat:
         """Returns the appropriate QuantityConverter instance."""
 
         return QuantityConverterFloat
 
-    def _get_unit_converter(self) -> UnitConverterFloat:
+    @staticmethod
+    def _get_unit_converter() -> UnitConverterFloat:
         """Returns the appropriate UnitConverter instance."""
 
         return UnitConverterFloat
@@ -221,7 +221,7 @@ class Inventory:
             contents_as_numbers = {
                 nuc: self._get_quantity_converter().activity_to_number(
                     self._get_unit_converter().activity_unit_conv(act, units, "Bq"),
-                    self._get_decay_const(nuc)
+                    self._get_decay_const(nuc),
                 )
                 for nuc, act in contents.items()
             }
@@ -236,7 +236,7 @@ class Inventory:
             contents_as_numbers = {
                 nuc: self._get_quantity_converter().mass_to_number(
                     self._get_unit_converter().mass_unit_conv(mass, units, "g"),
-                    self._get_atomic_mass(nuc)
+                    self._get_atomic_mass(nuc),
                 )
                 for nuc, mass in contents.items()
             }
@@ -291,7 +291,9 @@ class Inventory:
 
         activities = {
             nuc: self._get_unit_converter().activity_unit_conv(
-                self._get_quantity_converter().number_to_activity(num, self._get_decay_const(nuc)),
+                self._get_quantity_converter().number_to_activity(
+                    num, self._get_decay_const(nuc)
+                ),
                 "Bq",
                 units,
             )
@@ -319,7 +321,9 @@ class Inventory:
 
         masses = {
             nuc: self._get_unit_converter().mass_unit_conv(
-                self._get_quantity_converter().number_to_mass(num, self._get_atomic_mass(nuc)),
+                self._get_quantity_converter().number_to_mass(
+                    num, self._get_atomic_mass(nuc)
+                ),
                 "g",
                 units,
             )
@@ -644,7 +648,9 @@ class Inventory:
         Converts a decay time period into seconds.
         """
 
-        return self._get_unit_converter().time_unit_conv(decay_time, units, "s", self._get_year_conv())
+        return self._get_unit_converter().time_unit_conv(
+            decay_time, units, "s", self._get_year_conv()
+        )
 
     def _setup_decay_calc(
         self,
@@ -1142,7 +1148,8 @@ class InventoryHP(Inventory):
             )
         return self.decay_data.sympy_data
 
-    def _get_quantity_converter(self) -> QuantityConverterSympy:
+    @staticmethod
+    def _get_quantity_converter() -> QuantityConverterSympy:
         """
         Returns the appropriate QuantityConverter instance.
         """
@@ -1196,7 +1203,9 @@ class InventoryHP(Inventory):
         activities = {
             nuc: float(
                 self._get_unit_converter().activity_unit_conv(
-                    self._get_quantity_converter().number_to_activity(num, self._get_decay_const(nuc)),
+                    self._get_quantity_converter().number_to_activity(
+                        num, self._get_decay_const(nuc)
+                    ),
                     "Bq",
                     units,
                 )
@@ -1222,7 +1231,9 @@ class InventoryHP(Inventory):
         masses = {
             nuc: float(
                 self._get_unit_converter().mass_unit_conv(
-                    self._get_quantity_converter().number_to_mass(num, self._get_atomic_mass(nuc)),
+                    self._get_quantity_converter().number_to_mass(
+                        num, self._get_atomic_mass(nuc)
+                    ),
                     "g",
                     units,
                 )

--- a/radioactivedecay/inventory.py
+++ b/radioactivedecay/inventory.py
@@ -17,7 +17,7 @@ as `rd`:
 """
 
 from functools import singledispatch, update_wrapper
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 import matplotlib
 import numpy as np
 from scipy import sparse
@@ -170,13 +170,13 @@ class Inventory:
         return self.decay_data.scipy_data
 
     @staticmethod
-    def _get_quantity_converter() -> QuantityConverterFloat:
+    def _get_quantity_converter() -> Type[QuantityConverterFloat]:
         """Returns the appropriate QuantityConverter instance."""
 
         return QuantityConverterFloat
 
     @staticmethod
-    def _get_unit_converter() -> UnitConverterFloat:
+    def _get_unit_converter() -> Type[UnitConverterFloat]:
         """Returns the appropriate UnitConverter instance."""
 
         return UnitConverterFloat
@@ -585,7 +585,7 @@ class Inventory:
 
         self.contents = new_contents
 
-    @remove.register(int)  # type: ignore[no-redef]
+    @remove.register(int)
     def _(
         self, delete: int
     ) -> Callable[[Dict[str, float], str, bool, DecayData], None]:
@@ -601,7 +601,7 @@ class Inventory:
 
         self.contents = new_contents
 
-    @remove.register(Nuclide)  # type: ignore[no-redef]
+    @remove.register(Nuclide)
     def _(
         self, delete: Nuclide
     ) -> Callable[[Dict[str, float], str, bool, DecayData], None]:
@@ -617,7 +617,7 @@ class Inventory:
 
         self.contents = new_contents
 
-    @remove.register(list)  # type: ignore[no-redef]
+    @remove.register(list)
     def _(
         self, delete: List[Union[str, int, Nuclide]]
     ) -> Callable[[Dict[str, float], str, bool, DecayData], None]:
@@ -1149,14 +1149,14 @@ class InventoryHP(Inventory):
         return self.decay_data.sympy_data
 
     @staticmethod
-    def _get_quantity_converter() -> QuantityConverterSympy:
+    def _get_quantity_converter() -> Type[QuantityConverterSympy]:
         """
         Returns the appropriate QuantityConverter instance.
         """
 
         return QuantityConverterSympy
 
-    def _get_unit_converter(self) -> UnitConverterSympy:
+    def _get_unit_converter(self) -> Type[UnitConverterSympy]:
         """
         Returns the appropriate UnitConverter instance.
         """

--- a/radioactivedecay/nuclide.py
+++ b/radioactivedecay/nuclide.py
@@ -39,9 +39,9 @@ class Nuclide:
 
     Parameters
     ----------
-    input_nuclide : str or int
-        Input value for instantiation. Can be nuclide string in name
-        format (with or without hyphen), or canonical id (zzzaaassss).
+    nuclide : str or int
+        Specify the nuclide with either a name string (e.g. 'H-3', 'H3' or '3H') or a canonical id
+        (zzzaaassss format).
     decay_data : DecayData, optional
         Decay dataset (default is the ICRP-107 dataset).
 
@@ -55,28 +55,40 @@ class Nuclide:
     Examples
     --------
     >>> rd.Nuclide('K-40')
-    Nuclide: K-40
+    Nuclide: K-40, decay dataset: icrp107_ame2020_nubase2020
     >>> rd.Nuclide('K40')
-    Nuclide: K-40
+    Nuclide: K-40, decay dataset: icrp107_ame2020_nubase2020
     >>> rd.Nuclide(190400000)
-    Nuclide: K-40
+    Nuclide: K-40, decay dataset: icrp107_ame2020_nubase2020
     >>> rd.Nuclide(280560001)
-    Nuclide: Ni-56m
+    Nuclide: Ni-56m, decay dataset: icrp107_ame2020_nubase2020
 
     """
 
     def __init__(
-        self, input_nuclide: Union[str, int], decay_data: DecayData = DEFAULTDATA
+        self, nuclide: Union[str, int], decay_data: DecayData = DEFAULTDATA
     ) -> None:
         self.decay_data = decay_data
         self.nuclide = parse_nuclide(
-            input_nuclide, self.decay_data.nuclides, self.decay_data.dataset_name
+            nuclide, self.decay_data.nuclides, self.decay_data.dataset_name
         )
 
     @property
     def Z(self) -> int:
         """
         Returns the atomic number of the nuclide.
+
+        Returns
+        -------
+        int
+            Atomic number of the nuclide.
+
+        Examples
+        --------
+        >>> H3 = rd.Nuclide('H-3')
+        >>> H3.Z
+        1
+
         """
 
         return elem_to_Z(self.nuclide.split("-")[0])
@@ -84,7 +96,19 @@ class Nuclide:
     @property
     def A(self) -> int:
         """
-        Returns the atomic mass number of the nuclide.
+        Returns the mass number of the nuclide.
+
+        Returns
+        -------
+        int
+            Mass number of the nuclide.
+
+        Examples
+        --------
+        >>> H3 = rd.Nuclide('H-3')
+        >>> H3.A
+        3
+
         """
 
         return int(self.nuclide.split("-")[1].strip("mn"))
@@ -92,8 +116,23 @@ class Nuclide:
     @property
     def state(self) -> str:
         """
-        Returns the excited state letter. '' for ground state, 'm' for first excited state, 'n' for
-        second excited state, etc.
+        Returns the metastable state character, i.e. '' for ground state, 'm' for first metastable
+        state, 'n' for second metastable state, etc..
+
+        Returns
+        -------
+        str
+            Metastable state character.
+
+        Examples
+        --------
+        >>> H3 = rd.Nuclide('H-3')
+        >>> H3.state
+        ''
+        >>> Ba137m = rd.Nuclide('Ba-137m')
+        >>> Ba137m.state
+        'm'
+
         """
 
         return self.nuclide.split("-")[1].strip("0123456789")
@@ -103,6 +142,21 @@ class Nuclide:
         """
         Returns the canonical nuclide id, in zzzaaassss form. Ground state is 0000, first excited
         state ("m") is 0001, second ("n") is 0002, etc.
+
+        Returns
+        -------
+        int
+            Canonical id of the nuclide.
+
+        Examples
+        --------
+        >>> H3 = rd.Nuclide('H-3')
+        >>> H3.id
+        10030000
+        >>> Ba137m = rd.Nuclide('Ba-137m')
+        >>> Ba137m.id
+        561370001
+
         """
 
         return build_id(self.Z, self.A, self.state)
@@ -111,6 +165,21 @@ class Nuclide:
     def atomic_mass(self) -> float:
         """
         Returns the atomic mass of the nuclide, in g/mol.
+
+        Returns
+        -------
+        float
+            Atomic mass of the nuclide in g/mol.
+
+        Examples
+        --------
+        >>> H3 = rd.Nuclide('H-3')
+        >>> H3.atomic_mass
+        3.01604928132
+        >>> Ba137m = rd.Nuclide('Ba-137m')
+        >>> Ba137m.atomic_mass
+        136.9065375271172
+
         """
 
         return self.decay_data.scipy_data.atomic_masses[

--- a/radioactivedecay/nuclide.py
+++ b/radioactivedecay/nuclide.py
@@ -210,6 +210,8 @@ class Nuclide:
         >>> K40 = rd.Nuclide('K-40')
         >>> K40.half_life('y')
         1251000000.0
+        >>> K40.half_life('readable')
+        '1.251 By'
         >>> Fe56 = rd.Nuclide('Fe-56')
         >>> Fe56.half_life('readable')
         'stable'

--- a/radioactivedecay/utils.py
+++ b/radioactivedecay/utils.py
@@ -262,7 +262,7 @@ def build_nuclide_string(Z: int, A: int, meta_state: str = "") -> str:
 
     """
 
-    if Z not in Z_DICT.keys():
+    if Z not in Z_DICT:
         raise ValueError(str(Z) + " is not a valid atomic number")
 
     return_string = f"{Z_DICT[Z]}-{A}{meta_state}"

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -9,7 +9,7 @@ from radioactivedecay.converters import (
     AVOGADRO,
     UnitConverterFloat,
     UnitConverterSympy,
-    QuantityConverter,
+    QuantityConverterFloat,
     QuantityConverterSympy,
 )
 
@@ -309,6 +309,15 @@ class TestUnitConverterFloat(unittest.TestCase):
         with self.assertRaises(ValueError):
             UnitConverterFloat.moles_unit_conv(1.0, "tmol", 1.0)
 
+    def test___repr__(self) -> None:
+        """
+        Test UnitConverterFloat __repr__ strings.
+        """
+
+        self.assertEqual(
+            UnitConverterFloat.__repr__(), "UnitConverterFloat using double-precision floats."
+        )
+
 
 class TestUnitConverterSympy(unittest.TestCase):
     """
@@ -516,143 +525,83 @@ class TestUnitConverterSympy(unittest.TestCase):
         with self.assertRaises(ValueError):
             UnitConverterSympy.moles_unit_conv(Integer(1), "tmol", Integer(1))
 
-
-class TestQuantityConverter(unittest.TestCase):
-    """
-    Unit tests for the converters.py QuantityConverter class.
-    """
-
-    def test_instantiation(self) -> None:
+    def test___repr__(self) -> None:
         """
-        Test instantiation of QuantityConverter objects.
+        Test UnitConverterSympy __repr__ strings.
         """
 
-        nuclide_dict = {"H-3": 0, "He-3": 1}
-        atomic_masses = np.array([3.01604928132, 3.01602932197])
-        decay_consts = np.array([1.7828715741004621e-09, 0.0])
-        qconv = QuantityConverter(nuclide_dict, atomic_masses, decay_consts)
-        self.assertEqual(qconv.nuclide_dict["He-3"], 1)
-        self.assertEqual(qconv.atomic_masses[0], 3.01604928132)
-        self.assertEqual(qconv.decay_consts[1], 0)
-        self.assertEqual(qconv.avogadro, 6.02214076e23)
+        self.assertEqual(
+            UnitConverterSympy.__repr__(), "UnitConverterSympy using SymPy arbitrary precision calculations."
+        )
+
+
+class TestQuantityConverterFloat(unittest.TestCase):
+    """
+    Unit tests for the converters.py QuantityConverterFloat class.
+    """
+
+    def test_class_attribute(self) -> None:
+        """
+        Test class attribute of QuantityConverterFloat.
+        """
+
+        self.assertEqual(QuantityConverterFloat.avogadro, 6.02214076e23)
 
     def test_activity_to_number(self) -> None:
         """
         Test the conversion of activity in Bq to number of atoms.
         """
 
-        nuclide_dict = {"H-3": 0, "He-3": 1}
-        atomic_masses = np.array([3.01604928132, 3.01602932197])
-        decay_consts = np.array([1.7828715741004621e-09, 0.0])
-        qconv = QuantityConverter(nuclide_dict, atomic_masses, decay_consts)
-        self.assertEqual(qconv.activity_to_number("H-3", 1.0), 560892895.7794082)
+        self.assertEqual(QuantityConverterFloat.activity_to_number(1.0, 1.7828715741004621e-09), 560892895.7794082)
 
     def test_mass_to_number(self) -> None:
         """
         Test the conversion of mass in grams to number of atoms.
         """
 
-        nuclide_dict = {"H-3": 0, "He-3": 1}
-        atomic_masses = np.array([3.01604928132, 3.01602932197])
-        decay_consts = np.array([1.7828715741004621e-09, 0.0])
-        qconv = QuantityConverter(nuclide_dict, atomic_masses, decay_consts)
-
-        self.assertEqual(qconv.mass_to_number("H-3", 1.0), 1.996698395247825e23)
-        self.assertEqual(qconv.mass_to_number("He-3", 1.0), 1.9967116089131645e23)
+        self.assertEqual(QuantityConverterFloat.mass_to_number(1.0, 3.01604928132), 1.996698395247825e23)
+        self.assertEqual(QuantityConverterFloat.mass_to_number(1.0, 3.01602932197), 1.9967116089131645e23)
 
     def test_moles_to_number(self) -> None:
         """
         Test the conversion of number of moles to number of atoms.
         """
 
-        nuclide_dict = {"H-3": 0, "He-3": 1}
-        atomic_masses = np.array([3.01604928132, 3.01602932197])
-        decay_consts = np.array([1.7828715741004621e-09, 0.0])
-        qconv = QuantityConverter(nuclide_dict, atomic_masses, decay_consts)
-
-        self.assertEqual(qconv.moles_to_number(1.0), 6.02214076e23)
-        self.assertEqual(qconv.moles_to_number(0.0), 0.0)
+        self.assertEqual(QuantityConverterFloat.moles_to_number(1.0), 6.02214076e23)
+        self.assertEqual(QuantityConverterFloat.moles_to_number(0.0), 0.0)
 
     def test_number_to_activity(self) -> None:
         """
         Test the conversion of number of atoms to activity in Bq.
         """
 
-        nuclide_dict = {"H-3": 0, "He-3": 1}
-        atomic_masses = np.array([3.01604928132, 3.01602932197])
-        decay_consts = np.array([1.7828715741004621e-09, 0.0])
-        qconv = QuantityConverter(nuclide_dict, atomic_masses, decay_consts)
-
-        self.assertEqual(qconv.number_to_activity("H-3", 560892895.7794082), 1.0)
-        self.assertEqual(qconv.number_to_activity("He-3", 1.0), 0.0)
-        self.assertEqual(qconv.number_to_activity("He-3", 0.0), 0.0)
+        self.assertEqual(QuantityConverterFloat.number_to_activity(560892895.7794082, 1.7828715741004621e-09), 1.0)
+        self.assertEqual(QuantityConverterFloat.number_to_activity(1.0, 0.0), 0.0)
+        self.assertEqual(QuantityConverterFloat.number_to_activity(0.0, 0.0), 0.0)
 
     def test_number_to_mass(self) -> None:
         """
         Test the conversion of number of atoms to mass in grams.
         """
 
-        nuclide_dict = {"H-3": 0, "He-3": 1}
-        atomic_masses = np.array([3.01604928132, 3.01602932197])
-        decay_consts = np.array([1.7828715741004621e-09, 0.0])
-        qconv = QuantityConverter(nuclide_dict, atomic_masses, decay_consts)
-
-        self.assertEqual(qconv.number_to_mass("H-3", 1.996698395247825e23), 1.0)
-        self.assertEqual(qconv.number_to_mass("He-3", 1.9967116089131645e23), 1.0)
+        self.assertEqual(QuantityConverterFloat.number_to_mass(1.996698395247825e23, 3.01604928132), 1.0)
+        self.assertEqual(QuantityConverterFloat.number_to_mass(1.9967116089131645e23, 3.01602932197), 1.0)
 
     def test_number_to_moles(self) -> None:
         """
         Test the conversion of number of atoms to number of moles.
         """
 
-        nuclide_dict = {"H-3": 0, "He-3": 1}
-        atomic_masses = np.array([3.01604928132, 3.01602932197])
-        decay_consts = np.array([1.7828715741004621e-09, 0.0])
-        qconv = QuantityConverter(nuclide_dict, atomic_masses, decay_consts)
-
-        self.assertEqual(qconv.number_to_moles(6.02214076e23), 1.0)
-        self.assertEqual(qconv.number_to_moles(0.0), 0.0)
-
-    def test___eq__(self) -> None:
-        """
-        Test QuantityConveter equality.
-        """
-
-        nuclide_dict = {"H-3": 0, "He-3": 1}
-        atomic_masses = np.array([3.01604928132, 3.01602932197])
-        decay_consts = np.array([1.7828715741004621e-09, 0.0])
-        qconv1 = QuantityConverter(nuclide_dict, atomic_masses, decay_consts)
-        qconv2 = QuantityConverter(nuclide_dict, atomic_masses, decay_consts)
-        self.assertEqual(qconv1, qconv2)
-
-        self.assertFalse(qconv1 == "random object")
-
-    def test___neq__(self) -> None:
-        """
-        Test QuantityConveter inequality.
-        """
-
-        nuclide_dict = {"H-3": 0, "He-3": 1}
-        atomic_masses = np.array([3.01604928132, 3.01602932197])
-        decay_consts = np.array([1.7828715741004621e-09, 0.0])
-        qconv1 = QuantityConverter(nuclide_dict, atomic_masses, decay_consts)
-        decay_consts = np.array([1.7828715741004621e-09, 0.1])
-        qconv2 = QuantityConverter(nuclide_dict, atomic_masses, decay_consts)
-        self.assertNotEqual(qconv1, qconv2)
-
-        self.assertTrue(qconv1 != "random object")
+        self.assertEqual(QuantityConverterFloat.number_to_moles(6.02214076e23), 1.0)
+        self.assertEqual(QuantityConverterFloat.number_to_moles(0.0), 0.0)
 
     def test___repr__(self) -> None:
         """
-        Test QuantityConveter __repr__ strings.
+        Test QuantityConveterFloat __repr__ strings.
         """
 
-        nuclide_dict = {"H-3": 0, "He-3": 1}
-        atomic_masses = np.array([3.01604928132, 3.01602932197])
-        decay_consts = np.array([1.7828715741004621e-09, 0.0])
-        qconv = QuantityConverter(nuclide_dict, atomic_masses, decay_consts)
         self.assertEqual(
-            qconv.__repr__(), "QuantityConverter using double-precision floats."
+            QuantityConverterFloat.__repr__(), "QuantityConverterFloat using double-precision floats."
         )
 
 
@@ -661,42 +610,20 @@ class TestQuantityConverterSympy(unittest.TestCase):
     Unit tests for the converters.py QuantityConverterSympy class.
     """
 
-    def test_instantiation(self) -> None:
+    def test_class_attribute(self) -> None:
         """
-        Test instantiation of QuantityConverter objects.
+        Test class attribute of QuantityConverterSympy class.
         """
 
-        nuclide_dict = {"H-3": 0, "He-3": 1}
-        atomic_masses = [
-            Integer("15055351900000000000000000000000000") / Integer(75401232033),
-            Integer("60221407600000000000000000000000000") / Integer(301602932197),
-        ]
-        decay_consts = [(Integer(625) * log(2)) / Integer(242988330816), Integer(0)]
-
-        qcs = QuantityConverterSympy(nuclide_dict, atomic_masses, decay_consts)
-        self.assertEqual(qcs.nuclide_dict["He-3"], 1)
-        self.assertEqual(
-            qcs.atomic_masses[0],
-            Integer("15055351900000000000000000000000000") / Integer(75401232033),
-        )
-        self.assertEqual(qcs.decay_consts[1], Integer(0))
-        self.assertEqual(qcs.avogadro, Integer(602214076000000000000000))
+        self.assertEqual(QuantityConverterSympy.avogadro, Integer(602214076000000000000000))
 
     def test_activity_to_number(self) -> None:
         """
         Test the conversion of activity in Bq to number of atoms.
         """
 
-        nuclide_dict = {"H-3": 0, "He-3": 1}
-        atomic_masses = [
-            Integer("15055351900000000000000000000000000") / Integer(75401232033),
-            Integer("60221407600000000000000000000000000") / Integer(301602932197),
-        ]
-        decay_consts = [(Integer(625) * log(2)) / Integer(242988330816), Integer(0)]
-        qcs = QuantityConverterSympy(nuclide_dict, atomic_masses, decay_consts)
-
         self.assertEqual(
-            qcs.activity_to_number("H-3", Integer(1)),
+            QuantityConverterSympy.activity_to_number(Integer(1), (Integer(625) * log(2)) / Integer(242988330816)),
             Integer(242988330816) / (Integer(625) * log(2)),
         )
 
@@ -705,22 +632,14 @@ class TestQuantityConverterSympy(unittest.TestCase):
         Test the conversion of mass in grams to number of atoms.
         """
 
-        nuclide_dict = {"H-3": 0, "He-3": 1}
-        atomic_masses = [
-            Integer("15055351900000000000000000000000000") / Integer(75401232033),
-            Integer("60221407600000000000000000000000000") / Integer(301602932197),
-        ]
-        decay_consts = [(Integer(625) * log(2)) / Integer(242988330816), Integer(0)]
-        qcs = QuantityConverterSympy(nuclide_dict, atomic_masses, decay_consts)
-
         self.assertEqual(
-            qcs.mass_to_number("H-3", Integer(1)),
+            QuantityConverterSympy.mass_to_number(Integer(1), Integer("15055351900000000000000000000000000") / Integer(75401232033)),
             Integer(75401232033)
             / Integer("15055351900000000000000000000000000")
             * Integer("602214076000000000000000"),
         )
         self.assertEqual(
-            qcs.mass_to_number("He-3", Integer(1)),
+            QuantityConverterSympy.mass_to_number(Integer(1), Integer("60221407600000000000000000000000000") / Integer(301602932197)),
             Integer(301602932197)
             / Integer("60221407600000000000000000000000000")
             * Integer("602214076000000000000000"),
@@ -731,60 +650,36 @@ class TestQuantityConverterSympy(unittest.TestCase):
         Test the conversion of number of moles to number of atoms.
         """
 
-        nuclide_dict = {"H-3": 0, "He-3": 1}
-        atomic_masses = [
-            Integer("15055351900000000000000000000000000") / Integer(75401232033),
-            Integer("60221407600000000000000000000000000") / Integer(301602932197),
-        ]
-        decay_consts = [(Integer(625) * log(2)) / Integer(242988330816), Integer(0)]
-        qcs = QuantityConverterSympy(nuclide_dict, atomic_masses, decay_consts)
-
         self.assertEqual(
-            qcs.moles_to_number(Integer(1)), Integer("602214076000000000000000")
+            QuantityConverterSympy.moles_to_number(Integer(1)), Integer("602214076000000000000000")
         )
-        self.assertEqual(qcs.moles_to_number(Integer(0)), Integer(0))
+        self.assertEqual(QuantityConverterSympy.moles_to_number(Integer(0)), Integer(0))
 
     def test_number_to_activity(self) -> None:
         """
         Test the conversion of number of atoms to activity in Bq.
         """
 
-        nuclide_dict = {"H-3": 0, "He-3": 1}
-        atomic_masses = [
-            Integer("15055351900000000000000000000000000") / Integer(75401232033),
-            Integer("60221407600000000000000000000000000") / Integer(301602932197),
-        ]
-        decay_consts = [(Integer(625) * log(2)) / Integer(242988330816), Integer(0)]
-        qcs = QuantityConverterSympy(nuclide_dict, atomic_masses, decay_consts)
-
         self.assertEqual(
-            qcs.number_to_activity("H-3", Integer(1)),
-            Integer(625) * log(2) / Integer(242988330816),
+            QuantityConverterSympy.number_to_activity(Integer(1), (Integer(625) * log(2)) / Integer(242988330816)),
+            Integer(625) * log(2) / Integer(242988330816), 
         )
-        self.assertEqual(qcs.number_to_activity("He-3", Integer(0)), Integer(0))
-        self.assertEqual(qcs.number_to_activity("He-3", Integer(0)), Integer(0))
+        self.assertEqual(QuantityConverterSympy.number_to_activity(Integer(0), (Integer(625) * log(2)) / Integer(242988330816)), Integer(0))
+        self.assertEqual(QuantityConverterSympy.number_to_activity(Integer(0), Integer(0)), Integer(0))
 
     def test_number_to_mass(self) -> None:
         """
         Test the conversion of number of atoms to mass in grams.
         """
 
-        nuclide_dict = {"H-3": 0, "He-3": 1}
-        atomic_masses = [
-            Integer("15055351900000000000000000000000000") / Integer(75401232033),
-            Integer("60221407600000000000000000000000000") / Integer(301602932197),
-        ]
-        decay_consts = [(Integer(625) * log(2)) / Integer(242988330816), Integer(0)]
-        qcs = QuantityConverterSympy(nuclide_dict, atomic_masses, decay_consts)
-
         self.assertEqual(
-            qcs.number_to_mass("H-3", Integer(1)),
+            QuantityConverterSympy.number_to_mass(Integer(1), Integer("15055351900000000000000000000000000") / Integer(75401232033)),
             Integer("15055351900000000000000000000000000")
             / Integer(75401232033)
             / Integer("602214076000000000000000"),
         )
         self.assertEqual(
-            qcs.number_to_mass("He-3", Integer(1)),
+            QuantityConverterSympy.number_to_mass(Integer(1), Integer("60221407600000000000000000000000000") / Integer(301602932197)),
             Integer("60221407600000000000000000000000000")
             / Integer(301602932197)
             / Integer("602214076000000000000000"),
@@ -795,52 +690,18 @@ class TestQuantityConverterSympy(unittest.TestCase):
         Test the conversion of number of atoms to number of moles.
         """
 
-        nuclide_dict = {"H-3": 0, "He-3": 1}
-        atomic_masses = [
-            Integer("15055351900000000000000000000000000") / Integer(75401232033),
-            Integer("60221407600000000000000000000000000") / Integer(301602932197),
-        ]
-        decay_consts = [(Integer(625) * log(2)) / Integer(242988330816), Integer(0)]
-        qcs = QuantityConverterSympy(nuclide_dict, atomic_masses, decay_consts)
-
         self.assertEqual(
-            qcs.number_to_moles(Integer("602214076000000000000000")), Integer(1)
+            QuantityConverterSympy.number_to_moles(Integer("602214076000000000000000")), Integer(1)
         )
-        self.assertEqual(qcs.number_to_moles(Integer(0)), Integer(0))
-
-    def test___eq__(self) -> None:
-        """
-        Test QuantityConveterSympy equality.
-        """
-
-        nuclide_dict = {"H-3": 0, "He-3": 1}
-        atomic_masses = [
-            Integer("15055351900000000000000000000000000") / Integer(75401232033),
-            Integer("60221407600000000000000000000000000") / Integer(301602932197),
-        ]
-        decay_consts = [(Integer(625) * log(2)) / Integer(242988330816), Integer(0)]
-        qconv1 = QuantityConverterSympy(nuclide_dict, atomic_masses, decay_consts)
-        qconv2 = QuantityConverterSympy(nuclide_dict, atomic_masses, decay_consts)
-        self.assertEqual(qconv1, qconv2)
-
-        self.assertFalse(qconv1 == "random object")
+        self.assertEqual(QuantityConverterSympy.number_to_moles(Integer(0)), Integer(0))
 
     def test___repr__(self) -> None:
         """
         Test QuantityConveterSympy __repr__ strings.
         """
 
-        nuclide_dict = {"H-3": 0, "He-3": 1}
-        atomic_masses = [
-            Integer("15055351900000000000000000000000000") / Integer(75401232033),
-            Integer("60221407600000000000000000000000000") / Integer(301602932197),
-        ]
-        decay_consts = [(Integer(625) * log(2)) / Integer(242988330816), Integer(0)]
-        qcs = QuantityConverterSympy(nuclide_dict, atomic_masses, decay_consts)
-
         self.assertEqual(
-            qcs.__repr__(),
-            "QuantityConverterSympy using SymPy arbitrary precision calculations.",
+            QuantityConverterSympy.__repr__(), "QuantityConverterSympy using SymPy arbitrary precision calculations."
         )
 
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -21,7 +21,7 @@ class TestConverters(unittest.TestCase):
 
     def test_avogadro(self) -> None:
         """
-        Test instantiation of UnitConverterFloat objects.
+        Test module constants.
         """
 
         self.assertEqual(AVOGADRO, 6.02214076e23)
@@ -32,18 +32,16 @@ class TestUnitConverterFloat(unittest.TestCase):
     Unit tests for the converters.py UnitConverterFloat class.
     """
 
-    def test_instantiation(self) -> None:
+    def test_class_attributes(self) -> None:
         """
-        Test instantiation of UnitConverterFloat objects.
+        Test class attributes of UnitConverterFloat objects.
         """
 
-        year_conv = 365.2422
-        uconv = UnitConverterFloat(year_conv)
-        self.assertEqual(uconv.time_units["s"], 1.0)
-        self.assertEqual(uconv.time_units["y"], 86400.0 * year_conv)
-        self.assertEqual(uconv.activity_units["Bq"], 1.0)
-        self.assertEqual(uconv.mass_units["g"], 1.0)
-        self.assertEqual(uconv.moles_units["mol"], 1.0)
+        self.assertEqual(UnitConverterFloat.time_units["s"], 1.0)
+        self.assertEqual(UnitConverterFloat.time_units["y"], 86400.0)
+        self.assertEqual(UnitConverterFloat.activity_units["Bq"], 1.0)
+        self.assertEqual(UnitConverterFloat.mass_units["g"], 1.0)
+        self.assertEqual(UnitConverterFloat.moles_units["mol"], 1.0)
 
     def test_time_unit_conv_seconds(self) -> None:
         """
@@ -51,48 +49,47 @@ class TestUnitConverterFloat(unittest.TestCase):
         """
 
         year_conv = 365.2422
-        uconv = UnitConverterFloat(year_conv)
 
-        self.assertEqual(uconv.time_unit_conv(1.0, "s", "s"), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "s", year_conv), 1.0e0)
         self.assertAlmostEqual(
-            uconv.time_unit_conv(1.0, "s", "ps"), 1.0e12, places=(15 - 12)
+            UnitConverterFloat.time_unit_conv(1.0, "s", "ps", year_conv), 1.0e12, places=(15 - 12)
         )
         self.assertAlmostEqual(
-            uconv.time_unit_conv(1.0, "s", "ns"), 1.0e9, places=(15 - 9)
+            UnitConverterFloat.time_unit_conv(1.0, "s", "ns", year_conv), 1.0e9, places=(15 - 9)
         )
-        self.assertEqual(uconv.time_unit_conv(1.0, "s", "μs"), 1.0e6)
-        self.assertEqual(uconv.time_unit_conv(1.0, "s", "us"), 1.0e6)
-        self.assertEqual(uconv.time_unit_conv(1.0, "s", "ms"), 1.0e3)
-        self.assertEqual(uconv.time_unit_conv(1.0, "s", "m"), 1.0 / 60.0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "s", "h"), 1.0 / (60.0 ** 2))
-        self.assertEqual(uconv.time_unit_conv(1.0, "s", "d"), 1.0 / (60.0 ** 2 * 24.0))
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "μs", year_conv), 1.0e6)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "us", year_conv), 1.0e6)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "ms", year_conv), 1.0e3)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "m", year_conv), 1.0 / 60.0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "h", year_conv), 1.0 / (60.0 ** 2))
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "d", year_conv), 1.0 / (60.0 ** 2 * 24.0))
         self.assertEqual(
-            uconv.time_unit_conv(1.0, "s", "y"),
+            UnitConverterFloat.time_unit_conv(1.0, "s", "y", year_conv),
             1.0 / (60.0 ** 2 * 24.0 * year_conv),
         )
         self.assertAlmostEqual(
-            uconv.time_unit_conv(1.0, "ps", "s"), 1.0e-12, places=(12 + 15)
+            UnitConverterFloat.time_unit_conv(1.0, "ps", "s", year_conv), 1.0e-12, places=(12 + 15)
         )
         self.assertAlmostEqual(
-            uconv.time_unit_conv(1.0, "ns", "s"), 1.0e-9, places=(9 + 15)
+            UnitConverterFloat.time_unit_conv(1.0, "ns", "s", year_conv), 1.0e-9, places=(9 + 15)
         )
-        self.assertEqual(uconv.time_unit_conv(1.0, "μs", "s"), 1.0e-6)
-        self.assertEqual(uconv.time_unit_conv(1.0, "us", "s"), 1.0e-6)
-        self.assertEqual(uconv.time_unit_conv(1.0, "ms", "s"), 1.0e-3)
-        self.assertEqual(uconv.time_unit_conv(1.0, "m", "s"), 60.0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "h", "s"), (60.0 ** 2))
-        self.assertEqual(uconv.time_unit_conv(1.0, "d", "s"), (60.0 ** 2 * 24.0))
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "μs", "s", year_conv), 1.0e-6)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "us", "s", year_conv), 1.0e-6)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "ms", "s", year_conv), 1.0e-3)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "m", "s", year_conv), 60.0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "h", "s", year_conv), (60.0 ** 2))
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "d", "s", year_conv), (60.0 ** 2 * 24.0))
         self.assertEqual(
-            uconv.time_unit_conv(1.0, "y", "s"), (60.0 ** 2 * 24.0 * year_conv)
+            UnitConverterFloat.time_unit_conv(1.0, "y", "s", year_conv), (60.0 ** 2 * 24.0 * year_conv)
         )
 
         # Catch some incorrect time units
         with self.assertRaises(ValueError):
-            uconv.time_unit_conv(1.0, "ty", "y")
+            UnitConverterFloat.time_unit_conv(1.0, "ty", "y", year_conv)
         with self.assertRaises(ValueError):
-            uconv.time_unit_conv(1.0, "y", "ty")
+            UnitConverterFloat.time_unit_conv(1.0, "y", "ty", year_conv)
         with self.assertRaises(ValueError):
-            uconv.time_unit_conv(1.0, "ty", 1.0)
+            UnitConverterFloat.time_unit_conv(1.0, "ty", 1.0, year_conv)
 
     def test_time_unit_conv_spelling_variations(self) -> None:
         """
@@ -100,30 +97,29 @@ class TestUnitConverterFloat(unittest.TestCase):
         """
 
         year_conv = 365.2422
-        uconv = UnitConverterFloat(year_conv)
 
-        self.assertEqual(uconv.time_unit_conv(1.0, "s", "sec"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "s", "second"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "s", "seconds"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "h", "hr"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "h", "hour"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "h", "hours"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "d", "day"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "d", "days"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "y", "yr"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "y", "year"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "y", "years"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "sec", "s"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "second", "s"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "seconds", "s"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "hr", "h"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "hour", "h"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "hours", "h"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "day", "d"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "days", "d"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "yr", "y"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "year", "y"), 1.0e0)
-        self.assertEqual(uconv.time_unit_conv(1.0, "years", "y"), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "sec", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "second", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "seconds", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "h", "hr", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "h", "hour", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "h", "hours", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "d", "day", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "d", "days", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "y", "yr", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "y", "year", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "y", "years", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "sec", "s", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "second", "s", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "seconds", "s", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "hr", "h", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "hour", "h", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "hours", "h", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "day", "d", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "days", "d", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "yr", "y", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "year", "y", year_conv), 1.0e0)
+        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "years", "y", year_conv), 1.0e0)
 
     def test_time_unit_conv_year_prefixes(self) -> None:
         """
@@ -131,40 +127,39 @@ class TestUnitConverterFloat(unittest.TestCase):
         """
 
         year_conv = 365.2422
-        uconv = UnitConverterFloat(year_conv)
 
         self.assertAlmostEqual(
-            uconv.time_unit_conv(1.0, "y", "ky"), 1.0e-3, places=(3 + 15)
+            UnitConverterFloat.time_unit_conv(1.0, "y", "ky", year_conv), 1.0e-3, places=(3 + 15)
         )
         self.assertAlmostEqual(
-            uconv.time_unit_conv(1.0, "y", "My"), 1.0e-6, places=(6 + 15)
+            UnitConverterFloat.time_unit_conv(1.0, "y", "My", year_conv), 1.0e-6, places=(6 + 15)
         )
         self.assertAlmostEqual(
-            uconv.time_unit_conv(1.0, "y", "By"), 1.0e-9, places=(9 + 15)
+            UnitConverterFloat.time_unit_conv(1.0, "y", "By", year_conv), 1.0e-9, places=(9 + 15)
         )
         self.assertAlmostEqual(
-            uconv.time_unit_conv(1.0, "y", "Gy"), 1.0e-9, places=(9 + 15)
+            UnitConverterFloat.time_unit_conv(1.0, "y", "Gy", year_conv), 1.0e-9, places=(9 + 15)
         )
         self.assertAlmostEqual(
-            uconv.time_unit_conv(1.0, "y", "Ty"), 1.0e-12, places=(12 + 15)
+            UnitConverterFloat.time_unit_conv(1.0, "y", "Ty", year_conv), 1.0e-12, places=(12 + 15)
         )
         self.assertAlmostEqual(
-            uconv.time_unit_conv(1.0, "y", "Py"), 1.0e-15, places=(15 + 15)
+            UnitConverterFloat.time_unit_conv(1.0, "y", "Py", year_conv), 1.0e-15, places=(15 + 15)
         )
         self.assertAlmostEqual(
-            uconv.time_unit_conv(1.0, "ky", "y"), 1.0e3, places=(15 - 3)
+            UnitConverterFloat.time_unit_conv(1.0, "ky", "y", year_conv), 1.0e3, places=(15 - 3)
         )
         self.assertAlmostEqual(
-            uconv.time_unit_conv(1.0, "My", "y"), 1.0e6, places=(15 - 6)
+            UnitConverterFloat.time_unit_conv(1.0, "My", "y", year_conv), 1.0e6, places=(15 - 6)
         )
         self.assertAlmostEqual(
-            uconv.time_unit_conv(1.0, "Gy", "y"), 1.0e9, places=(15 - 9)
+            UnitConverterFloat.time_unit_conv(1.0, "Gy", "y", year_conv), 1.0e9, places=(15 - 9)
         )
         self.assertAlmostEqual(
-            uconv.time_unit_conv(1.0, "Ty", "y"), 1.0e12, places=(15 - 12)
+            UnitConverterFloat.time_unit_conv(1.0, "Ty", "y", year_conv), 1.0e12, places=(15 - 12)
         )
         self.assertAlmostEqual(
-            uconv.time_unit_conv(1.0, "Py", "y"), 1.0e15, places=(15 - 15)
+            UnitConverterFloat.time_unit_conv(1.0, "Py", "y", year_conv), 1.0e15, places=(15 - 15)
         )
 
     def test_activity_unit_conv(self) -> None:
@@ -172,185 +167,147 @@ class TestUnitConverterFloat(unittest.TestCase):
         Test conversions between activity units.
         """
 
-        uconv = UnitConverterFloat(365.2422)
-
-        self.assertEqual(uconv.activity_unit_conv(1.0, "Bq", "Bq"), 1.0e0)
+        self.assertEqual(UnitConverterFloat.activity_unit_conv(1.0, "Bq", "Bq"), 1.0e0)
         self.assertAlmostEqual(
-            uconv.activity_unit_conv(1.0, "Bq", "pBq"), 1.0e12, places=(15 - 12)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "pBq"), 1.0e12, places=(15 - 12)
         )
         self.assertAlmostEqual(
-            uconv.activity_unit_conv(1.0, "Bq", "nBq"), 1.0e9, places=(15 - 9)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "nBq"), 1.0e9, places=(15 - 9)
         )
-        self.assertEqual(uconv.activity_unit_conv(1.0, "Bq", "μBq"), 1.0e6)
-        self.assertEqual(uconv.activity_unit_conv(1.0, "Bq", "uBq"), 1.0e6)
-        self.assertEqual(uconv.activity_unit_conv(1.0, "Bq", "mBq"), 1.0e3)
+        self.assertEqual(UnitConverterFloat.activity_unit_conv(1.0, "Bq", "μBq"), 1.0e6)
+        self.assertEqual(UnitConverterFloat.activity_unit_conv(1.0, "Bq", "uBq"), 1.0e6)
+        self.assertEqual(UnitConverterFloat.activity_unit_conv(1.0, "Bq", "mBq"), 1.0e3)
         self.assertAlmostEqual(
-            uconv.activity_unit_conv(1.0, "Bq", "kBq"), 1.0e-3, places=(3 + 15)
-        )
-        self.assertAlmostEqual(
-            uconv.activity_unit_conv(1.0, "Bq", "MBq"), 1.0e-6, places=(6 + 15)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "kBq"), 1.0e-3, places=(3 + 15)
         )
         self.assertAlmostEqual(
-            uconv.activity_unit_conv(1.0, "Bq", "GBq"), 1.0e-9, places=(9 + 15)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "MBq"), 1.0e-6, places=(6 + 15)
         )
         self.assertAlmostEqual(
-            uconv.activity_unit_conv(1.0, "Bq", "TBq"), 1.0e-12, places=(12 + 15)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "GBq"), 1.0e-9, places=(9 + 15)
         )
         self.assertAlmostEqual(
-            uconv.activity_unit_conv(1.0, "Bq", "PBq"), 1.0e-15, places=(15 + 15)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "TBq"), 1.0e-12, places=(12 + 15)
         )
         self.assertAlmostEqual(
-            uconv.activity_unit_conv(1.0, "Bq", "EBq"), 1.0e-18, places=(18 + 15)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "PBq"), 1.0e-15, places=(15 + 15)
+        )
+        self.assertAlmostEqual(
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "EBq"), 1.0e-18, places=(18 + 15)
         )
 
         self.assertAlmostEqual(
-            uconv.activity_unit_conv(1.0, "Bq", "pCi"),
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "pCi"),
             1.0e12 / 3.7e10,
             places=(15 - 12),
         )
         self.assertAlmostEqual(
-            uconv.activity_unit_conv(1.0, "Bq", "nCi"), 1.0e9 / 3.7e10, places=(15 - 9)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "nCi"), 1.0e9 / 3.7e10, places=(15 - 9)
         )
-        self.assertEqual(uconv.activity_unit_conv(1.0, "Bq", "μCi"), 1.0e6 / 3.7e10)
-        self.assertEqual(uconv.activity_unit_conv(1.0, "Bq", "uCi"), 1.0e6 / 3.7e10)
-        self.assertEqual(uconv.activity_unit_conv(1.0, "Bq", "mCi"), 1.0e3 / 3.7e10)
-        self.assertEqual(uconv.activity_unit_conv(1.0, "Bq", "Ci"), 1.0 / 3.7e10)
+        self.assertEqual(UnitConverterFloat.activity_unit_conv(1.0, "Bq", "μCi"), 1.0e6 / 3.7e10)
+        self.assertEqual(UnitConverterFloat.activity_unit_conv(1.0, "Bq", "uCi"), 1.0e6 / 3.7e10)
+        self.assertEqual(UnitConverterFloat.activity_unit_conv(1.0, "Bq", "mCi"), 1.0e3 / 3.7e10)
+        self.assertEqual(UnitConverterFloat.activity_unit_conv(1.0, "Bq", "Ci"), 1.0 / 3.7e10)
         self.assertAlmostEqual(
-            uconv.activity_unit_conv(1.0, "Bq", "kCi"), 1.0e-3 / 3.7e10, places=(3 + 15)
-        )
-        self.assertAlmostEqual(
-            uconv.activity_unit_conv(1.0, "Bq", "MCi"), 1.0e-6 / 3.7e10, places=(6 + 15)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "kCi"), 1.0e-3 / 3.7e10, places=(3 + 15)
         )
         self.assertAlmostEqual(
-            uconv.activity_unit_conv(1.0, "Bq", "GCi"), 1.0e-9 / 3.7e10, places=(9 + 15)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "MCi"), 1.0e-6 / 3.7e10, places=(6 + 15)
         )
         self.assertAlmostEqual(
-            uconv.activity_unit_conv(1.0, "Bq", "TCi"),
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "GCi"), 1.0e-9 / 3.7e10, places=(9 + 15)
+        )
+        self.assertAlmostEqual(
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "TCi"),
             1.0e-12 / 3.7e10,
             places=(12 + 15),
         )
         self.assertAlmostEqual(
-            uconv.activity_unit_conv(1.0, "Bq", "PCi"),
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "PCi"),
             1.0e-15 / 3.7e10,
             places=(15 + 15),
         )
         self.assertAlmostEqual(
-            uconv.activity_unit_conv(1.0, "Bq", "ECi"),
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "ECi"),
             1.0e-18 / 3.7e10,
             places=(18 + 15),
         )
 
-        self.assertEqual(uconv.activity_unit_conv(1.0, "Bq", "dpm"), 1.0 / 60.0)
+        self.assertEqual(UnitConverterFloat.activity_unit_conv(1.0, "Bq", "dpm"), 1.0 / 60.0)
 
         # Catch some incorrect activity units
         with self.assertRaises(ValueError):
-            uconv.activity_unit_conv(1.0, "tBq", "Bq")
+            UnitConverterFloat.activity_unit_conv(1.0, "tBq", "Bq")
         with self.assertRaises(ValueError):
-            uconv.activity_unit_conv(1.0, "Bq", "tBq")
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "tBq")
         with self.assertRaises(ValueError):
-            uconv.activity_unit_conv(1.0, "tBq", 1.0)
+            UnitConverterFloat.activity_unit_conv(1.0, "tBq", 1.0)
 
     def test_mass_unit_conv(self) -> None:
         """
         Test conversions between mass units.
         """
 
-        uconv = UnitConverterFloat(365.2422)
-
-        self.assertEqual(uconv.mass_unit_conv(1.0, "g", "g"), 1.0e0)
+        self.assertEqual(UnitConverterFloat.mass_unit_conv(1.0, "g", "g"), 1.0e0)
         self.assertAlmostEqual(
-            uconv.mass_unit_conv(1.0, "g", "pg"), 1.0e12, places=(15 - 12)
+            UnitConverterFloat.mass_unit_conv(1.0, "g", "pg"), 1.0e12, places=(15 - 12)
         )
         self.assertAlmostEqual(
-            uconv.mass_unit_conv(1.0, "g", "ng"), 1.0e9, places=(15 - 9)
+            UnitConverterFloat.mass_unit_conv(1.0, "g", "ng"), 1.0e9, places=(15 - 9)
         )
-        self.assertEqual(uconv.mass_unit_conv(1.0, "g", "μg"), 1.0e6)
-        self.assertEqual(uconv.mass_unit_conv(1.0, "g", "ug"), 1.0e6)
-        self.assertEqual(uconv.mass_unit_conv(1.0, "g", "mg"), 1.0e3)
+        self.assertEqual(UnitConverterFloat.mass_unit_conv(1.0, "g", "μg"), 1.0e6)
+        self.assertEqual(UnitConverterFloat.mass_unit_conv(1.0, "g", "ug"), 1.0e6)
+        self.assertEqual(UnitConverterFloat.mass_unit_conv(1.0, "g", "mg"), 1.0e3)
         self.assertAlmostEqual(
-            uconv.mass_unit_conv(1.0, "g", "kg"), 1.0e-3, places=(3 + 15)
-        )
-        self.assertAlmostEqual(
-            uconv.mass_unit_conv(1.0, "g", "Mg"), 1.0e-6, places=(6 + 15)
+            UnitConverterFloat.mass_unit_conv(1.0, "g", "kg"), 1.0e-3, places=(3 + 15)
         )
         self.assertAlmostEqual(
-            uconv.mass_unit_conv(1.0, "g", "t"), 1.0e-6, places=(6 + 15)
+            UnitConverterFloat.mass_unit_conv(1.0, "g", "Mg"), 1.0e-6, places=(6 + 15)
         )
         self.assertAlmostEqual(
-            uconv.mass_unit_conv(1.0, "g", "ton"), 1.0e-6, places=(6 + 15)
+            UnitConverterFloat.mass_unit_conv(1.0, "g", "t"), 1.0e-6, places=(6 + 15)
+        )
+        self.assertAlmostEqual(
+            UnitConverterFloat.mass_unit_conv(1.0, "g", "ton"), 1.0e-6, places=(6 + 15)
         )
 
         # Catch some incorrect activity units
         with self.assertRaises(ValueError):
-            uconv.mass_unit_conv(1.0, "tg", "g")
+            UnitConverterFloat.mass_unit_conv(1.0, "tg", "g")
         with self.assertRaises(ValueError):
-            uconv.mass_unit_conv(1.0, "g", "tg")
+            UnitConverterFloat.mass_unit_conv(1.0, "g", "tg")
         with self.assertRaises(ValueError):
-            uconv.mass_unit_conv(1.0, "tg", 1.0)
+            UnitConverterFloat.mass_unit_conv(1.0, "tg", 1.0)
 
     def test_moles_unit_conv(self) -> None:
         """
         Test conversions between moles orders of magnitude.
         """
 
-        uconv = UnitConverterFloat(365.2422)
-
-        self.assertEqual(uconv.moles_unit_conv(1.0, "mol", "mol"), 1.0e0)
+        self.assertEqual(UnitConverterFloat.moles_unit_conv(1.0, "mol", "mol"), 1.0e0)
         self.assertAlmostEqual(
-            uconv.moles_unit_conv(1.0, "mol", "pmol"), 1.0e12, places=(15 - 12)
+            UnitConverterFloat.moles_unit_conv(1.0, "mol", "pmol"), 1.0e12, places=(15 - 12)
         )
         self.assertAlmostEqual(
-            uconv.moles_unit_conv(1.0, "mol", "nmol"), 1.0e9, places=(15 - 9)
+            UnitConverterFloat.moles_unit_conv(1.0, "mol", "nmol"), 1.0e9, places=(15 - 9)
         )
-        self.assertEqual(uconv.moles_unit_conv(1.0, "mol", "μmol"), 1.0e6)
-        self.assertEqual(uconv.moles_unit_conv(1.0, "mol", "umol"), 1.0e6)
-        self.assertEqual(uconv.moles_unit_conv(1.0, "mol", "mmol"), 1.0e3)
+        self.assertEqual(UnitConverterFloat.moles_unit_conv(1.0, "mol", "μmol"), 1.0e6)
+        self.assertEqual(UnitConverterFloat.moles_unit_conv(1.0, "mol", "umol"), 1.0e6)
+        self.assertEqual(UnitConverterFloat.moles_unit_conv(1.0, "mol", "mmol"), 1.0e3)
         self.assertAlmostEqual(
-            uconv.moles_unit_conv(1.0, "mol", "kmol"), 1.0e-3, places=(3 + 15)
+            UnitConverterFloat.moles_unit_conv(1.0, "mol", "kmol"), 1.0e-3, places=(3 + 15)
         )
         self.assertAlmostEqual(
-            uconv.moles_unit_conv(1.0, "mol", "Mmol"), 1.0e-6, places=(6 + 15)
+            UnitConverterFloat.moles_unit_conv(1.0, "mol", "Mmol"), 1.0e-6, places=(6 + 15)
         )
 
         # Catch some incorrect activity units
         with self.assertRaises(ValueError):
-            uconv.moles_unit_conv(1.0, "tmol", "mol")
+            UnitConverterFloat.moles_unit_conv(1.0, "tmol", "mol")
         with self.assertRaises(ValueError):
-            uconv.moles_unit_conv(1.0, "mol", "tmol")
+            UnitConverterFloat.moles_unit_conv(1.0, "mol", "tmol")
         with self.assertRaises(ValueError):
-            uconv.moles_unit_conv(1.0, "tmol", 1.0)
-
-    def test___eq__(self) -> None:
-        """
-        Test UnitConverterFloat equality.
-        """
-
-        uc1 = UnitConverterFloat(365.2422)
-        uc2 = UnitConverterFloat(365.2422)
-        self.assertEqual(uc1, uc2)
-
-        self.assertFalse(uc1 == "random object")
-
-    def test___neq__(self) -> None:
-        """
-        Test UnitConverterFloat inequality.
-        """
-
-        uc1 = UnitConverterFloat(365.2422)
-        uc2 = UnitConverterFloat(365.25)
-        self.assertNotEqual(uc1, uc2)
-
-        self.assertTrue(uc1 != "random object")
-
-    def test___repr__(self) -> None:
-        """
-        Test UnitConverterFloat __repr__ strings.
-        """
-
-        uconv = UnitConverterFloat(365.2422)
-        self.assertEqual(
-            uconv.__repr__(), "UnitConverterFloat using 365.2422 days in a year."
-        )
+            UnitConverterFloat.moles_unit_conv(1.0, "tmol", 1.0)
 
 
 class TestUnitConverterSympy(unittest.TestCase):
@@ -358,18 +315,16 @@ class TestUnitConverterSympy(unittest.TestCase):
     Unit tests for the converters.py UnitConverterSympy class.
     """
 
-    def test_instantiation(self) -> None:
+    def test_class_attributes(self) -> None:
         """
-        Test instantiation of UnitConverterSympy objects.
+        Test class attributes of UnitConverterSympy objects.
         """
 
-        year_conv = Integer(3652422) / Integer(10000)
-        ucs = UnitConverterSympy(year_conv)
-        self.assertEqual(ucs.time_units["s"], Integer(1))
-        self.assertEqual(ucs.time_units["y"], Integer(86400) * year_conv)
-        self.assertEqual(ucs.activity_units["Bq"], Integer(1))
-        self.assertEqual(ucs.mass_units["g"], Integer(1))
-        self.assertEqual(ucs.moles_units["mol"], Integer(1))
+        self.assertEqual(UnitConverterSympy.time_units["s"], Integer(1))
+        self.assertEqual(UnitConverterSympy.time_units["y"], Integer(86400))
+        self.assertEqual(UnitConverterSympy.activity_units["Bq"], Integer(1))
+        self.assertEqual(UnitConverterSympy.mass_units["g"], Integer(1))
+        self.assertEqual(UnitConverterSympy.moles_units["mol"], Integer(1))
 
     def test_time_unit_conv(self) -> None:
         """
@@ -377,210 +332,189 @@ class TestUnitConverterSympy(unittest.TestCase):
         """
 
         year_conv = Integer(3652422) / 10000
-        ucs = UnitConverterSympy(year_conv)
 
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "ps", "ns"), 1 / Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "ns", "us"), 1 / Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "μs", "ms"), 1 / Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "us", "ms"), 1 / Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "ms", "s"), 1 / Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "s", "m"), 1 / Integer(60))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "m", "h"), 1 / Integer(60))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "h", "d"), 1 / Integer(24))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "ps", "ns", year_conv), 1 / Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "ns", "us", year_conv), 1 / Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "μs", "ms", year_conv), 1 / Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "us", "ms", year_conv), 1 / Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "ms", "s", year_conv), 1 / Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "s", "m", year_conv), 1 / Integer(60))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "m", "h", year_conv), 1 / Integer(60))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "h", "d", year_conv), 1 / Integer(24))
         self.assertEqual(
-            ucs.time_unit_conv(Integer(1), "d", "y"), 10000 / Integer(3652422)
+            UnitConverterSympy.time_unit_conv(Integer(1), "d", "y", year_conv), 10000 / Integer(3652422)
         )
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "y", "ky"), 1 / Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "ky", "My"), 1 / Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "My", "By"), 1 / Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "My", "Gy"), 1 / Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "By", "Ty"), 1 / Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "Gy", "Ty"), 1 / Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "Ty", "Py"), 1 / Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "y", "ky", year_conv), 1 / Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "ky", "My", year_conv), 1 / Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "My", "By", year_conv), 1 / Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "My", "Gy", year_conv), 1 / Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "By", "Ty", year_conv), 1 / Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "Gy", "Ty", year_conv), 1 / Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "Ty", "Py", year_conv), 1 / Integer(1000))
 
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "ns", "ps"), Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "μs", "ns"), Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "us", "ns"), Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "ms", "us"), Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "s", "ms"), Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "m", "s"), Integer(60))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "h", "m"), Integer(60))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "d", "h"), Integer(24))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "ns", "ps", year_conv), Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "μs", "ns", year_conv), Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "us", "ns", year_conv), Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "ms", "us", year_conv), Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "s", "ms", year_conv), Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "m", "s", year_conv), Integer(60))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "h", "m", year_conv), Integer(60))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "d", "h", year_conv), Integer(24))
         self.assertEqual(
-            ucs.time_unit_conv(Integer(1), "y", "d"), Integer(3652422) / 10000
+            UnitConverterSympy.time_unit_conv(Integer(1), "y", "d", year_conv), Integer(3652422) / 10000
         )
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "ky", "y"), Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "My", "ky"), Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "By", "My"), Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "Gy", "My"), Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "Ty", "By"), Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "Ty", "Gy"), Integer(1000))
-        self.assertEqual(ucs.time_unit_conv(Integer(1), "Py", "Ty"), Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "ky", "y", year_conv), Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "My", "ky", year_conv), Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "By", "My", year_conv), Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "Gy", "My", year_conv), Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "Ty", "By", year_conv), Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "Ty", "Gy", year_conv), Integer(1000))
+        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "Py", "Ty", year_conv), Integer(1000))
 
         # Catch some incorrect time units
         with self.assertRaises(ValueError):
-            ucs.time_unit_conv(Integer(1), "ty", "y")
+            UnitConverterSympy.time_unit_conv(Integer(1), "ty", "y", year_conv)
         with self.assertRaises(ValueError):
-            ucs.time_unit_conv(Integer(1), "y", "ty")
+            UnitConverterSympy.time_unit_conv(Integer(1), "y", "ty", year_conv)
         with self.assertRaises(ValueError):
-            ucs.time_unit_conv(Integer(1), "ty", Integer(1))
+            UnitConverterSympy.time_unit_conv(Integer(1), "ty", Integer(1), year_conv)
 
     def test_activity_unit_conv(self) -> None:
         """
         Test of the SymPy version of activity_unit_conv().
         """
 
-        year_conv = Integer(3652422) / 10000
-        ucs = UnitConverterSympy(year_conv)
-
         self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "pBq", "nBq"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "pBq", "nBq"), 1 / Integer(1000)
         )
         self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "nBq", "μBq"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "nBq", "μBq"), 1 / Integer(1000)
         )
-        self.assertEqual(ucs.activity_unit_conv(Integer(1), "μBq", "uBq"), Integer(1))
+        self.assertEqual(UnitConverterSympy.activity_unit_conv(Integer(1), "μBq", "uBq"), Integer(1))
         self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "uBq", "mBq"), 1 / Integer(1000)
-        )
-        self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "mBq", "Bq"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "uBq", "mBq"), 1 / Integer(1000)
         )
         self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "Bq", "kBq"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "mBq", "Bq"), 1 / Integer(1000)
         )
         self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "kBq", "MBq"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "Bq", "kBq"), 1 / Integer(1000)
         )
         self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "MBq", "GBq"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "kBq", "MBq"), 1 / Integer(1000)
         )
         self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "GBq", "TBq"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "MBq", "GBq"), 1 / Integer(1000)
         )
         self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "TBq", "PBq"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "GBq", "TBq"), 1 / Integer(1000)
+        )
+        self.assertEqual(
+            UnitConverterSympy.activity_unit_conv(Integer(1), "TBq", "PBq"), 1 / Integer(1000)
         )
 
         self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "pBq", "pCi"), 1 / Integer(37000000000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "pBq", "pCi"), 1 / Integer(37000000000)
         )
         self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "pCi", "nCi"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "pCi", "nCi"), 1 / Integer(1000)
         )
         self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "nCi", "μCi"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "nCi", "μCi"), 1 / Integer(1000)
         )
-        self.assertEqual(ucs.activity_unit_conv(Integer(1), "μCi", "uCi"), Integer(1))
+        self.assertEqual(UnitConverterSympy.activity_unit_conv(Integer(1), "μCi", "uCi"), Integer(1))
         self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "uCi", "mCi"), 1 / Integer(1000)
-        )
-        self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "mCi", "Ci"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "uCi", "mCi"), 1 / Integer(1000)
         )
         self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "Ci", "kCi"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "mCi", "Ci"), 1 / Integer(1000)
         )
         self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "kCi", "MCi"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "Ci", "kCi"), 1 / Integer(1000)
         )
         self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "MCi", "GCi"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "kCi", "MCi"), 1 / Integer(1000)
         )
         self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "GCi", "TCi"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "MCi", "GCi"), 1 / Integer(1000)
         )
         self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "TCi", "PCi"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "GCi", "TCi"), 1 / Integer(1000)
         )
         self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "PCi", "ECi"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "TCi", "PCi"), 1 / Integer(1000)
+        )
+        self.assertEqual(
+            UnitConverterSympy.activity_unit_conv(Integer(1), "PCi", "ECi"), 1 / Integer(1000)
         )
 
         self.assertEqual(
-            ucs.activity_unit_conv(Integer(1), "Bq", "dpm"), 1 / Integer(60)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "Bq", "dpm"), 1 / Integer(60)
         )
 
         # Catch some incorrect activity units
         with self.assertRaises(ValueError):
-            ucs.activity_unit_conv(Integer(1), "tBq", "Bq")
+            UnitConverterSympy.activity_unit_conv(Integer(1), "tBq", "Bq")
         with self.assertRaises(ValueError):
-            ucs.activity_unit_conv(Integer(1), "Bq", "tBq")
+            UnitConverterSympy.activity_unit_conv(Integer(1), "Bq", "tBq")
         with self.assertRaises(ValueError):
-            ucs.activity_unit_conv(Integer(1), "tBq", Integer(1))
+            UnitConverterSympy.activity_unit_conv(Integer(1), "tBq", Integer(1))
 
     def test_mass_unit_conv(self) -> None:
         """
         Test of the SymPy version of mass_unit_conv().
         """
 
-        year_conv = Integer(3652422) / 10000
-        ucs = UnitConverterSympy(year_conv)
-
-        self.assertEqual(ucs.mass_unit_conv(Integer(1), "pg", "ng"), 1 / Integer(1000))
-        self.assertEqual(ucs.mass_unit_conv(Integer(1), "ng", "μg"), 1 / Integer(1000))
-        self.assertEqual(ucs.mass_unit_conv(Integer(1), "μg", "ug"), Integer(1))
-        self.assertEqual(ucs.mass_unit_conv(Integer(1), "ug", "mg"), 1 / Integer(1000))
-        self.assertEqual(ucs.mass_unit_conv(Integer(1), "mg", "g"), 1 / Integer(1000))
-        self.assertEqual(ucs.mass_unit_conv(Integer(1), "g", "kg"), 1 / Integer(1000))
-        self.assertEqual(ucs.mass_unit_conv(Integer(1), "kg", "Mg"), 1 / Integer(1000))
-        self.assertEqual(ucs.mass_unit_conv(Integer(1), "Mg", "t"), Integer(1))
-        self.assertEqual(ucs.mass_unit_conv(Integer(1), "Mg", "ton"), Integer(1))
+        self.assertEqual(UnitConverterSympy.mass_unit_conv(Integer(1), "pg", "ng"), 1 / Integer(1000))
+        self.assertEqual(UnitConverterSympy.mass_unit_conv(Integer(1), "ng", "μg"), 1 / Integer(1000))
+        self.assertEqual(UnitConverterSympy.mass_unit_conv(Integer(1), "μg", "ug"), Integer(1))
+        self.assertEqual(UnitConverterSympy.mass_unit_conv(Integer(1), "ug", "mg"), 1 / Integer(1000))
+        self.assertEqual(UnitConverterSympy.mass_unit_conv(Integer(1), "mg", "g"), 1 / Integer(1000))
+        self.assertEqual(UnitConverterSympy.mass_unit_conv(Integer(1), "g", "kg"), 1 / Integer(1000))
+        self.assertEqual(UnitConverterSympy.mass_unit_conv(Integer(1), "kg", "Mg"), 1 / Integer(1000))
+        self.assertEqual(UnitConverterSympy.mass_unit_conv(Integer(1), "Mg", "t"), Integer(1))
+        self.assertEqual(UnitConverterSympy.mass_unit_conv(Integer(1), "Mg", "ton"), Integer(1))
 
         # Catch some incorrect activity units
         with self.assertRaises(ValueError):
-            ucs.mass_unit_conv(Integer(1), "tg", "g")
+            UnitConverterSympy.mass_unit_conv(Integer(1), "tg", "g")
         with self.assertRaises(ValueError):
-            ucs.mass_unit_conv(Integer(1), "g", "tg")
+            UnitConverterSympy.mass_unit_conv(Integer(1), "g", "tg")
         with self.assertRaises(ValueError):
-            ucs.mass_unit_conv(Integer(1), "tg", Integer(1))
+            UnitConverterSympy.mass_unit_conv(Integer(1), "tg", Integer(1))
 
     def test_moles_unit_conv(self) -> None:
         """
         Test of the SymPy version of moles_unit_conv().
         """
 
-        year_conv = Integer(3652422) / 10000
-        ucs = UnitConverterSympy(year_conv)
-
         self.assertEqual(
-            ucs.moles_unit_conv(Integer(1), "pmol", "nmol"), 1 / Integer(1000)
+            UnitConverterSympy.moles_unit_conv(Integer(1), "pmol", "nmol"), 1 / Integer(1000)
         )
         self.assertEqual(
-            ucs.moles_unit_conv(Integer(1), "nmol", "μmol"), 1 / Integer(1000)
+            UnitConverterSympy.moles_unit_conv(Integer(1), "nmol", "μmol"), 1 / Integer(1000)
         )
-        self.assertEqual(ucs.moles_unit_conv(Integer(1), "μmol", "umol"), Integer(1))
+        self.assertEqual(UnitConverterSympy.moles_unit_conv(Integer(1), "μmol", "umol"), Integer(1))
         self.assertEqual(
-            ucs.moles_unit_conv(Integer(1), "umol", "mmol"), 1 / Integer(1000)
-        )
-        self.assertEqual(
-            ucs.moles_unit_conv(Integer(1), "mmol", "mol"), 1 / Integer(1000)
+            UnitConverterSympy.moles_unit_conv(Integer(1), "umol", "mmol"), 1 / Integer(1000)
         )
         self.assertEqual(
-            ucs.moles_unit_conv(Integer(1), "mol", "kmol"), 1 / Integer(1000)
+            UnitConverterSympy.moles_unit_conv(Integer(1), "mmol", "mol"), 1 / Integer(1000)
         )
         self.assertEqual(
-            ucs.moles_unit_conv(Integer(1), "kmol", "Mmol"), 1 / Integer(1000)
+            UnitConverterSympy.moles_unit_conv(Integer(1), "mol", "kmol"), 1 / Integer(1000)
+        )
+        self.assertEqual(
+            UnitConverterSympy.moles_unit_conv(Integer(1), "kmol", "Mmol"), 1 / Integer(1000)
         )
 
         # Catch some incorrect activity units
         with self.assertRaises(ValueError):
-            ucs.moles_unit_conv(Integer(1), "tmol", "mol")
+            UnitConverterSympy.moles_unit_conv(Integer(1), "tmol", "mol")
         with self.assertRaises(ValueError):
-            ucs.moles_unit_conv(Integer(1), "mol", "tmol")
+            UnitConverterSympy.moles_unit_conv(Integer(1), "mol", "tmol")
         with self.assertRaises(ValueError):
-            ucs.moles_unit_conv(Integer(1), "tmol", Integer(1))
-
-    def test___repr__(self) -> None:
-        """
-        Test UnitConverterSympy __repr__ strings.
-        """
-
-        year_conv = Integer(3652422) / 10000
-        ucs = UnitConverterSympy(year_conv)
-        self.assertEqual(
-            ucs.__repr__(), "UnitConverterSympy using 1826211/5000 days in a year."
-        )
+            UnitConverterSympy.moles_unit_conv(Integer(1), "tmol", Integer(1))
 
 
 class TestQuantityConverter(unittest.TestCase):

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -3,7 +3,6 @@ Unit tests for converts.py classes and methods.
 """
 
 import unittest
-import numpy as np
 from sympy import Integer, log
 from radioactivedecay.converters import (
     AVOGADRO,
@@ -50,37 +49,75 @@ class TestUnitConverterFloat(unittest.TestCase):
 
         year_conv = 365.2422
 
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "s", year_conv), 1.0e0)
-        self.assertAlmostEqual(
-            UnitConverterFloat.time_unit_conv(1.0, "s", "ps", year_conv), 1.0e12, places=(15 - 12)
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "s", "s", year_conv), 1.0e0
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.time_unit_conv(1.0, "s", "ns", year_conv), 1.0e9, places=(15 - 9)
+            UnitConverterFloat.time_unit_conv(1.0, "s", "ps", year_conv),
+            1.0e12,
+            places=(15 - 12),
         )
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "μs", year_conv), 1.0e6)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "us", year_conv), 1.0e6)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "ms", year_conv), 1.0e3)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "m", year_conv), 1.0 / 60.0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "h", year_conv), 1.0 / (60.0 ** 2))
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "d", year_conv), 1.0 / (60.0 ** 2 * 24.0))
+        self.assertAlmostEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "s", "ns", year_conv),
+            1.0e9,
+            places=(15 - 9),
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "s", "μs", year_conv), 1.0e6
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "s", "us", year_conv), 1.0e6
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "s", "ms", year_conv), 1.0e3
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "s", "m", year_conv), 1.0 / 60.0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "s", "h", year_conv),
+            1.0 / (60.0 ** 2),
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "s", "d", year_conv),
+            1.0 / (60.0 ** 2 * 24.0),
+        )
         self.assertEqual(
             UnitConverterFloat.time_unit_conv(1.0, "s", "y", year_conv),
             1.0 / (60.0 ** 2 * 24.0 * year_conv),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.time_unit_conv(1.0, "ps", "s", year_conv), 1.0e-12, places=(12 + 15)
+            UnitConverterFloat.time_unit_conv(1.0, "ps", "s", year_conv),
+            1.0e-12,
+            places=(12 + 15),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.time_unit_conv(1.0, "ns", "s", year_conv), 1.0e-9, places=(9 + 15)
+            UnitConverterFloat.time_unit_conv(1.0, "ns", "s", year_conv),
+            1.0e-9,
+            places=(9 + 15),
         )
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "μs", "s", year_conv), 1.0e-6)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "us", "s", year_conv), 1.0e-6)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "ms", "s", year_conv), 1.0e-3)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "m", "s", year_conv), 60.0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "h", "s", year_conv), (60.0 ** 2))
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "d", "s", year_conv), (60.0 ** 2 * 24.0))
         self.assertEqual(
-            UnitConverterFloat.time_unit_conv(1.0, "y", "s", year_conv), (60.0 ** 2 * 24.0 * year_conv)
+            UnitConverterFloat.time_unit_conv(1.0, "μs", "s", year_conv), 1.0e-6
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "us", "s", year_conv), 1.0e-6
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "ms", "s", year_conv), 1.0e-3
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "m", "s", year_conv), 60.0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "h", "s", year_conv), (60.0 ** 2)
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "d", "s", year_conv),
+            (60.0 ** 2 * 24.0),
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "y", "s", year_conv),
+            (60.0 ** 2 * 24.0 * year_conv),
         )
 
         # Catch some incorrect time units
@@ -98,28 +135,72 @@ class TestUnitConverterFloat(unittest.TestCase):
 
         year_conv = 365.2422
 
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "sec", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "second", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "s", "seconds", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "h", "hr", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "h", "hour", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "h", "hours", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "d", "day", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "d", "days", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "y", "yr", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "y", "year", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "y", "years", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "sec", "s", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "second", "s", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "seconds", "s", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "hr", "h", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "hour", "h", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "hours", "h", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "day", "d", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "days", "d", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "yr", "y", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "year", "y", year_conv), 1.0e0)
-        self.assertEqual(UnitConverterFloat.time_unit_conv(1.0, "years", "y", year_conv), 1.0e0)
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "s", "sec", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "s", "second", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "s", "seconds", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "h", "hr", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "h", "hour", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "h", "hours", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "d", "day", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "d", "days", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "y", "yr", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "y", "year", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "y", "years", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "sec", "s", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "second", "s", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "seconds", "s", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "hr", "h", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "hour", "h", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "hours", "h", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "day", "d", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "days", "d", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "yr", "y", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "year", "y", year_conv), 1.0e0
+        )
+        self.assertEqual(
+            UnitConverterFloat.time_unit_conv(1.0, "years", "y", year_conv), 1.0e0
+        )
 
     def test_time_unit_conv_year_prefixes(self) -> None:
         """
@@ -129,37 +210,59 @@ class TestUnitConverterFloat(unittest.TestCase):
         year_conv = 365.2422
 
         self.assertAlmostEqual(
-            UnitConverterFloat.time_unit_conv(1.0, "y", "ky", year_conv), 1.0e-3, places=(3 + 15)
+            UnitConverterFloat.time_unit_conv(1.0, "y", "ky", year_conv),
+            1.0e-3,
+            places=(3 + 15),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.time_unit_conv(1.0, "y", "My", year_conv), 1.0e-6, places=(6 + 15)
+            UnitConverterFloat.time_unit_conv(1.0, "y", "My", year_conv),
+            1.0e-6,
+            places=(6 + 15),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.time_unit_conv(1.0, "y", "By", year_conv), 1.0e-9, places=(9 + 15)
+            UnitConverterFloat.time_unit_conv(1.0, "y", "By", year_conv),
+            1.0e-9,
+            places=(9 + 15),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.time_unit_conv(1.0, "y", "Gy", year_conv), 1.0e-9, places=(9 + 15)
+            UnitConverterFloat.time_unit_conv(1.0, "y", "Gy", year_conv),
+            1.0e-9,
+            places=(9 + 15),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.time_unit_conv(1.0, "y", "Ty", year_conv), 1.0e-12, places=(12 + 15)
+            UnitConverterFloat.time_unit_conv(1.0, "y", "Ty", year_conv),
+            1.0e-12,
+            places=(12 + 15),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.time_unit_conv(1.0, "y", "Py", year_conv), 1.0e-15, places=(15 + 15)
+            UnitConverterFloat.time_unit_conv(1.0, "y", "Py", year_conv),
+            1.0e-15,
+            places=(15 + 15),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.time_unit_conv(1.0, "ky", "y", year_conv), 1.0e3, places=(15 - 3)
+            UnitConverterFloat.time_unit_conv(1.0, "ky", "y", year_conv),
+            1.0e3,
+            places=(15 - 3),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.time_unit_conv(1.0, "My", "y", year_conv), 1.0e6, places=(15 - 6)
+            UnitConverterFloat.time_unit_conv(1.0, "My", "y", year_conv),
+            1.0e6,
+            places=(15 - 6),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.time_unit_conv(1.0, "Gy", "y", year_conv), 1.0e9, places=(15 - 9)
+            UnitConverterFloat.time_unit_conv(1.0, "Gy", "y", year_conv),
+            1.0e9,
+            places=(15 - 9),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.time_unit_conv(1.0, "Ty", "y", year_conv), 1.0e12, places=(15 - 12)
+            UnitConverterFloat.time_unit_conv(1.0, "Ty", "y", year_conv),
+            1.0e12,
+            places=(15 - 12),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.time_unit_conv(1.0, "Py", "y", year_conv), 1.0e15, places=(15 - 15)
+            UnitConverterFloat.time_unit_conv(1.0, "Py", "y", year_conv),
+            1.0e15,
+            places=(15 - 15),
         )
 
     def test_activity_unit_conv(self) -> None:
@@ -169,31 +272,47 @@ class TestUnitConverterFloat(unittest.TestCase):
 
         self.assertEqual(UnitConverterFloat.activity_unit_conv(1.0, "Bq", "Bq"), 1.0e0)
         self.assertAlmostEqual(
-            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "pBq"), 1.0e12, places=(15 - 12)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "pBq"),
+            1.0e12,
+            places=(15 - 12),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "nBq"), 1.0e9, places=(15 - 9)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "nBq"),
+            1.0e9,
+            places=(15 - 9),
         )
         self.assertEqual(UnitConverterFloat.activity_unit_conv(1.0, "Bq", "μBq"), 1.0e6)
         self.assertEqual(UnitConverterFloat.activity_unit_conv(1.0, "Bq", "uBq"), 1.0e6)
         self.assertEqual(UnitConverterFloat.activity_unit_conv(1.0, "Bq", "mBq"), 1.0e3)
         self.assertAlmostEqual(
-            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "kBq"), 1.0e-3, places=(3 + 15)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "kBq"),
+            1.0e-3,
+            places=(3 + 15),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "MBq"), 1.0e-6, places=(6 + 15)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "MBq"),
+            1.0e-6,
+            places=(6 + 15),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "GBq"), 1.0e-9, places=(9 + 15)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "GBq"),
+            1.0e-9,
+            places=(9 + 15),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "TBq"), 1.0e-12, places=(12 + 15)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "TBq"),
+            1.0e-12,
+            places=(12 + 15),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "PBq"), 1.0e-15, places=(15 + 15)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "PBq"),
+            1.0e-15,
+            places=(15 + 15),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "EBq"), 1.0e-18, places=(18 + 15)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "EBq"),
+            1.0e-18,
+            places=(18 + 15),
         )
 
         self.assertAlmostEqual(
@@ -202,20 +321,36 @@ class TestUnitConverterFloat(unittest.TestCase):
             places=(15 - 12),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "nCi"), 1.0e9 / 3.7e10, places=(15 - 9)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "nCi"),
+            1.0e9 / 3.7e10,
+            places=(15 - 9),
         )
-        self.assertEqual(UnitConverterFloat.activity_unit_conv(1.0, "Bq", "μCi"), 1.0e6 / 3.7e10)
-        self.assertEqual(UnitConverterFloat.activity_unit_conv(1.0, "Bq", "uCi"), 1.0e6 / 3.7e10)
-        self.assertEqual(UnitConverterFloat.activity_unit_conv(1.0, "Bq", "mCi"), 1.0e3 / 3.7e10)
-        self.assertEqual(UnitConverterFloat.activity_unit_conv(1.0, "Bq", "Ci"), 1.0 / 3.7e10)
-        self.assertAlmostEqual(
-            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "kCi"), 1.0e-3 / 3.7e10, places=(3 + 15)
+        self.assertEqual(
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "μCi"), 1.0e6 / 3.7e10
+        )
+        self.assertEqual(
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "uCi"), 1.0e6 / 3.7e10
+        )
+        self.assertEqual(
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "mCi"), 1.0e3 / 3.7e10
+        )
+        self.assertEqual(
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "Ci"), 1.0 / 3.7e10
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "MCi"), 1.0e-6 / 3.7e10, places=(6 + 15)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "kCi"),
+            1.0e-3 / 3.7e10,
+            places=(3 + 15),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "GCi"), 1.0e-9 / 3.7e10, places=(9 + 15)
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "MCi"),
+            1.0e-6 / 3.7e10,
+            places=(6 + 15),
+        )
+        self.assertAlmostEqual(
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "GCi"),
+            1.0e-9 / 3.7e10,
+            places=(9 + 15),
         )
         self.assertAlmostEqual(
             UnitConverterFloat.activity_unit_conv(1.0, "Bq", "TCi"),
@@ -233,7 +368,9 @@ class TestUnitConverterFloat(unittest.TestCase):
             places=(18 + 15),
         )
 
-        self.assertEqual(UnitConverterFloat.activity_unit_conv(1.0, "Bq", "dpm"), 1.0 / 60.0)
+        self.assertEqual(
+            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "dpm"), 1.0 / 60.0
+        )
 
         # Catch some incorrect activity units
         with self.assertRaises(ValueError):
@@ -286,19 +423,27 @@ class TestUnitConverterFloat(unittest.TestCase):
 
         self.assertEqual(UnitConverterFloat.moles_unit_conv(1.0, "mol", "mol"), 1.0e0)
         self.assertAlmostEqual(
-            UnitConverterFloat.moles_unit_conv(1.0, "mol", "pmol"), 1.0e12, places=(15 - 12)
+            UnitConverterFloat.moles_unit_conv(1.0, "mol", "pmol"),
+            1.0e12,
+            places=(15 - 12),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.moles_unit_conv(1.0, "mol", "nmol"), 1.0e9, places=(15 - 9)
+            UnitConverterFloat.moles_unit_conv(1.0, "mol", "nmol"),
+            1.0e9,
+            places=(15 - 9),
         )
         self.assertEqual(UnitConverterFloat.moles_unit_conv(1.0, "mol", "μmol"), 1.0e6)
         self.assertEqual(UnitConverterFloat.moles_unit_conv(1.0, "mol", "umol"), 1.0e6)
         self.assertEqual(UnitConverterFloat.moles_unit_conv(1.0, "mol", "mmol"), 1.0e3)
         self.assertAlmostEqual(
-            UnitConverterFloat.moles_unit_conv(1.0, "mol", "kmol"), 1.0e-3, places=(3 + 15)
+            UnitConverterFloat.moles_unit_conv(1.0, "mol", "kmol"),
+            1.0e-3,
+            places=(3 + 15),
         )
         self.assertAlmostEqual(
-            UnitConverterFloat.moles_unit_conv(1.0, "mol", "Mmol"), 1.0e-6, places=(6 + 15)
+            UnitConverterFloat.moles_unit_conv(1.0, "mol", "Mmol"),
+            1.0e-6,
+            places=(6 + 15),
         )
 
         # Catch some incorrect activity units
@@ -315,7 +460,8 @@ class TestUnitConverterFloat(unittest.TestCase):
         """
 
         self.assertEqual(
-            UnitConverterFloat.__repr__(), "UnitConverterFloat using double-precision floats."
+            UnitConverterFloat.__repr__(),
+            "UnitConverterFloat using double-precision floats.",
         )
 
 
@@ -342,43 +488,135 @@ class TestUnitConverterSympy(unittest.TestCase):
 
         year_conv = Integer(3652422) / 10000
 
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "ps", "ns", year_conv), 1 / Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "ns", "us", year_conv), 1 / Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "μs", "ms", year_conv), 1 / Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "us", "ms", year_conv), 1 / Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "ms", "s", year_conv), 1 / Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "s", "m", year_conv), 1 / Integer(60))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "m", "h", year_conv), 1 / Integer(60))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "h", "d", year_conv), 1 / Integer(24))
         self.assertEqual(
-            UnitConverterSympy.time_unit_conv(Integer(1), "d", "y", year_conv), 10000 / Integer(3652422)
+            UnitConverterSympy.time_unit_conv(Integer(1), "ps", "ns", year_conv),
+            1 / Integer(1000),
         )
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "y", "ky", year_conv), 1 / Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "ky", "My", year_conv), 1 / Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "My", "By", year_conv), 1 / Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "My", "Gy", year_conv), 1 / Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "By", "Ty", year_conv), 1 / Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "Gy", "Ty", year_conv), 1 / Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "Ty", "Py", year_conv), 1 / Integer(1000))
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "ns", "us", year_conv),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "μs", "ms", year_conv),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "us", "ms", year_conv),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "ms", "s", year_conv),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "s", "m", year_conv),
+            1 / Integer(60),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "m", "h", year_conv),
+            1 / Integer(60),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "h", "d", year_conv),
+            1 / Integer(24),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "d", "y", year_conv),
+            10000 / Integer(3652422),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "y", "ky", year_conv),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "ky", "My", year_conv),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "My", "By", year_conv),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "My", "Gy", year_conv),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "By", "Ty", year_conv),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "Gy", "Ty", year_conv),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "Ty", "Py", year_conv),
+            1 / Integer(1000),
+        )
 
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "ns", "ps", year_conv), Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "μs", "ns", year_conv), Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "us", "ns", year_conv), Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "ms", "us", year_conv), Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "s", "ms", year_conv), Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "m", "s", year_conv), Integer(60))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "h", "m", year_conv), Integer(60))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "d", "h", year_conv), Integer(24))
         self.assertEqual(
-            UnitConverterSympy.time_unit_conv(Integer(1), "y", "d", year_conv), Integer(3652422) / 10000
+            UnitConverterSympy.time_unit_conv(Integer(1), "ns", "ps", year_conv),
+            Integer(1000),
         )
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "ky", "y", year_conv), Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "My", "ky", year_conv), Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "By", "My", year_conv), Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "Gy", "My", year_conv), Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "Ty", "By", year_conv), Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "Ty", "Gy", year_conv), Integer(1000))
-        self.assertEqual(UnitConverterSympy.time_unit_conv(Integer(1), "Py", "Ty", year_conv), Integer(1000))
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "μs", "ns", year_conv),
+            Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "us", "ns", year_conv),
+            Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "ms", "us", year_conv),
+            Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "s", "ms", year_conv),
+            Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "m", "s", year_conv),
+            Integer(60),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "h", "m", year_conv),
+            Integer(60),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "d", "h", year_conv),
+            Integer(24),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "y", "d", year_conv),
+            Integer(3652422) / 10000,
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "ky", "y", year_conv),
+            Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "My", "ky", year_conv),
+            Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "By", "My", year_conv),
+            Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "Gy", "My", year_conv),
+            Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "Ty", "By", year_conv),
+            Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "Ty", "Gy", year_conv),
+            Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.time_unit_conv(Integer(1), "Py", "Ty", year_conv),
+            Integer(1000),
+        )
 
         # Catch some incorrect time units
         with self.assertRaises(ValueError):
@@ -394,71 +632,96 @@ class TestUnitConverterSympy(unittest.TestCase):
         """
 
         self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "pBq", "nBq"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "pBq", "nBq"),
+            1 / Integer(1000),
         )
         self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "nBq", "μBq"), 1 / Integer(1000)
-        )
-        self.assertEqual(UnitConverterSympy.activity_unit_conv(Integer(1), "μBq", "uBq"), Integer(1))
-        self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "uBq", "mBq"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "nBq", "μBq"),
+            1 / Integer(1000),
         )
         self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "mBq", "Bq"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "μBq", "uBq"), Integer(1)
         )
         self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "Bq", "kBq"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "uBq", "mBq"),
+            1 / Integer(1000),
         )
         self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "kBq", "MBq"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "mBq", "Bq"),
+            1 / Integer(1000),
         )
         self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "MBq", "GBq"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "Bq", "kBq"),
+            1 / Integer(1000),
         )
         self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "GBq", "TBq"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "kBq", "MBq"),
+            1 / Integer(1000),
         )
         self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "TBq", "PBq"), 1 / Integer(1000)
-        )
-
-        self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "pBq", "pCi"), 1 / Integer(37000000000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "MBq", "GBq"),
+            1 / Integer(1000),
         )
         self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "pCi", "nCi"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "GBq", "TBq"),
+            1 / Integer(1000),
         )
         self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "nCi", "μCi"), 1 / Integer(1000)
-        )
-        self.assertEqual(UnitConverterSympy.activity_unit_conv(Integer(1), "μCi", "uCi"), Integer(1))
-        self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "uCi", "mCi"), 1 / Integer(1000)
-        )
-        self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "mCi", "Ci"), 1 / Integer(1000)
-        )
-        self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "Ci", "kCi"), 1 / Integer(1000)
-        )
-        self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "kCi", "MCi"), 1 / Integer(1000)
-        )
-        self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "MCi", "GCi"), 1 / Integer(1000)
-        )
-        self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "GCi", "TCi"), 1 / Integer(1000)
-        )
-        self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "TCi", "PCi"), 1 / Integer(1000)
-        )
-        self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "PCi", "ECi"), 1 / Integer(1000)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "TBq", "PBq"),
+            1 / Integer(1000),
         )
 
         self.assertEqual(
-            UnitConverterSympy.activity_unit_conv(Integer(1), "Bq", "dpm"), 1 / Integer(60)
+            UnitConverterSympy.activity_unit_conv(Integer(1), "pBq", "pCi"),
+            1 / Integer(37000000000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.activity_unit_conv(Integer(1), "pCi", "nCi"),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.activity_unit_conv(Integer(1), "nCi", "μCi"),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.activity_unit_conv(Integer(1), "μCi", "uCi"), Integer(1)
+        )
+        self.assertEqual(
+            UnitConverterSympy.activity_unit_conv(Integer(1), "uCi", "mCi"),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.activity_unit_conv(Integer(1), "mCi", "Ci"),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.activity_unit_conv(Integer(1), "Ci", "kCi"),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.activity_unit_conv(Integer(1), "kCi", "MCi"),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.activity_unit_conv(Integer(1), "MCi", "GCi"),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.activity_unit_conv(Integer(1), "GCi", "TCi"),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.activity_unit_conv(Integer(1), "TCi", "PCi"),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.activity_unit_conv(Integer(1), "PCi", "ECi"),
+            1 / Integer(1000),
+        )
+
+        self.assertEqual(
+            UnitConverterSympy.activity_unit_conv(Integer(1), "Bq", "dpm"),
+            1 / Integer(60),
         )
 
         # Catch some incorrect activity units
@@ -474,15 +737,33 @@ class TestUnitConverterSympy(unittest.TestCase):
         Test of the SymPy version of mass_unit_conv().
         """
 
-        self.assertEqual(UnitConverterSympy.mass_unit_conv(Integer(1), "pg", "ng"), 1 / Integer(1000))
-        self.assertEqual(UnitConverterSympy.mass_unit_conv(Integer(1), "ng", "μg"), 1 / Integer(1000))
-        self.assertEqual(UnitConverterSympy.mass_unit_conv(Integer(1), "μg", "ug"), Integer(1))
-        self.assertEqual(UnitConverterSympy.mass_unit_conv(Integer(1), "ug", "mg"), 1 / Integer(1000))
-        self.assertEqual(UnitConverterSympy.mass_unit_conv(Integer(1), "mg", "g"), 1 / Integer(1000))
-        self.assertEqual(UnitConverterSympy.mass_unit_conv(Integer(1), "g", "kg"), 1 / Integer(1000))
-        self.assertEqual(UnitConverterSympy.mass_unit_conv(Integer(1), "kg", "Mg"), 1 / Integer(1000))
-        self.assertEqual(UnitConverterSympy.mass_unit_conv(Integer(1), "Mg", "t"), Integer(1))
-        self.assertEqual(UnitConverterSympy.mass_unit_conv(Integer(1), "Mg", "ton"), Integer(1))
+        self.assertEqual(
+            UnitConverterSympy.mass_unit_conv(Integer(1), "pg", "ng"), 1 / Integer(1000)
+        )
+        self.assertEqual(
+            UnitConverterSympy.mass_unit_conv(Integer(1), "ng", "μg"), 1 / Integer(1000)
+        )
+        self.assertEqual(
+            UnitConverterSympy.mass_unit_conv(Integer(1), "μg", "ug"), Integer(1)
+        )
+        self.assertEqual(
+            UnitConverterSympy.mass_unit_conv(Integer(1), "ug", "mg"), 1 / Integer(1000)
+        )
+        self.assertEqual(
+            UnitConverterSympy.mass_unit_conv(Integer(1), "mg", "g"), 1 / Integer(1000)
+        )
+        self.assertEqual(
+            UnitConverterSympy.mass_unit_conv(Integer(1), "g", "kg"), 1 / Integer(1000)
+        )
+        self.assertEqual(
+            UnitConverterSympy.mass_unit_conv(Integer(1), "kg", "Mg"), 1 / Integer(1000)
+        )
+        self.assertEqual(
+            UnitConverterSympy.mass_unit_conv(Integer(1), "Mg", "t"), Integer(1)
+        )
+        self.assertEqual(
+            UnitConverterSympy.mass_unit_conv(Integer(1), "Mg", "ton"), Integer(1)
+        )
 
         # Catch some incorrect activity units
         with self.assertRaises(ValueError):
@@ -498,23 +779,31 @@ class TestUnitConverterSympy(unittest.TestCase):
         """
 
         self.assertEqual(
-            UnitConverterSympy.moles_unit_conv(Integer(1), "pmol", "nmol"), 1 / Integer(1000)
+            UnitConverterSympy.moles_unit_conv(Integer(1), "pmol", "nmol"),
+            1 / Integer(1000),
         )
         self.assertEqual(
-            UnitConverterSympy.moles_unit_conv(Integer(1), "nmol", "μmol"), 1 / Integer(1000)
-        )
-        self.assertEqual(UnitConverterSympy.moles_unit_conv(Integer(1), "μmol", "umol"), Integer(1))
-        self.assertEqual(
-            UnitConverterSympy.moles_unit_conv(Integer(1), "umol", "mmol"), 1 / Integer(1000)
+            UnitConverterSympy.moles_unit_conv(Integer(1), "nmol", "μmol"),
+            1 / Integer(1000),
         )
         self.assertEqual(
-            UnitConverterSympy.moles_unit_conv(Integer(1), "mmol", "mol"), 1 / Integer(1000)
+            UnitConverterSympy.moles_unit_conv(Integer(1), "μmol", "umol"), Integer(1)
         )
         self.assertEqual(
-            UnitConverterSympy.moles_unit_conv(Integer(1), "mol", "kmol"), 1 / Integer(1000)
+            UnitConverterSympy.moles_unit_conv(Integer(1), "umol", "mmol"),
+            1 / Integer(1000),
         )
         self.assertEqual(
-            UnitConverterSympy.moles_unit_conv(Integer(1), "kmol", "Mmol"), 1 / Integer(1000)
+            UnitConverterSympy.moles_unit_conv(Integer(1), "mmol", "mol"),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.moles_unit_conv(Integer(1), "mol", "kmol"),
+            1 / Integer(1000),
+        )
+        self.assertEqual(
+            UnitConverterSympy.moles_unit_conv(Integer(1), "kmol", "Mmol"),
+            1 / Integer(1000),
         )
 
         # Catch some incorrect activity units
@@ -531,7 +820,8 @@ class TestUnitConverterSympy(unittest.TestCase):
         """
 
         self.assertEqual(
-            UnitConverterSympy.__repr__(), "UnitConverterSympy using SymPy arbitrary precision calculations."
+            UnitConverterSympy.__repr__(),
+            "UnitConverterSympy using SymPy arbitrary precision calculations.",
         )
 
 
@@ -552,15 +842,24 @@ class TestQuantityConverterFloat(unittest.TestCase):
         Test the conversion of activity in Bq to number of atoms.
         """
 
-        self.assertEqual(QuantityConverterFloat.activity_to_number(1.0, 1.7828715741004621e-09), 560892895.7794082)
+        self.assertEqual(
+            QuantityConverterFloat.activity_to_number(1.0, 1.7828715741004621e-09),
+            560892895.7794082,
+        )
 
     def test_mass_to_number(self) -> None:
         """
         Test the conversion of mass in grams to number of atoms.
         """
 
-        self.assertEqual(QuantityConverterFloat.mass_to_number(1.0, 3.01604928132), 1.996698395247825e23)
-        self.assertEqual(QuantityConverterFloat.mass_to_number(1.0, 3.01602932197), 1.9967116089131645e23)
+        self.assertEqual(
+            QuantityConverterFloat.mass_to_number(1.0, 3.01604928132),
+            1.996698395247825e23,
+        )
+        self.assertEqual(
+            QuantityConverterFloat.mass_to_number(1.0, 3.01602932197),
+            1.9967116089131645e23,
+        )
 
     def test_moles_to_number(self) -> None:
         """
@@ -575,7 +874,12 @@ class TestQuantityConverterFloat(unittest.TestCase):
         Test the conversion of number of atoms to activity in Bq.
         """
 
-        self.assertEqual(QuantityConverterFloat.number_to_activity(560892895.7794082, 1.7828715741004621e-09), 1.0)
+        self.assertEqual(
+            QuantityConverterFloat.number_to_activity(
+                560892895.7794082, 1.7828715741004621e-09
+            ),
+            1.0,
+        )
         self.assertEqual(QuantityConverterFloat.number_to_activity(1.0, 0.0), 0.0)
         self.assertEqual(QuantityConverterFloat.number_to_activity(0.0, 0.0), 0.0)
 
@@ -584,8 +888,14 @@ class TestQuantityConverterFloat(unittest.TestCase):
         Test the conversion of number of atoms to mass in grams.
         """
 
-        self.assertEqual(QuantityConverterFloat.number_to_mass(1.996698395247825e23, 3.01604928132), 1.0)
-        self.assertEqual(QuantityConverterFloat.number_to_mass(1.9967116089131645e23, 3.01602932197), 1.0)
+        self.assertEqual(
+            QuantityConverterFloat.number_to_mass(1.996698395247825e23, 3.01604928132),
+            1.0,
+        )
+        self.assertEqual(
+            QuantityConverterFloat.number_to_mass(1.9967116089131645e23, 3.01602932197),
+            1.0,
+        )
 
     def test_number_to_moles(self) -> None:
         """
@@ -601,7 +911,8 @@ class TestQuantityConverterFloat(unittest.TestCase):
         """
 
         self.assertEqual(
-            QuantityConverterFloat.__repr__(), "QuantityConverterFloat using double-precision floats."
+            QuantityConverterFloat.__repr__(),
+            "QuantityConverterFloat using double-precision floats.",
         )
 
 
@@ -615,7 +926,9 @@ class TestQuantityConverterSympy(unittest.TestCase):
         Test class attribute of QuantityConverterSympy class.
         """
 
-        self.assertEqual(QuantityConverterSympy.avogadro, Integer(602214076000000000000000))
+        self.assertEqual(
+            QuantityConverterSympy.avogadro, Integer(602214076000000000000000)
+        )
 
     def test_activity_to_number(self) -> None:
         """
@@ -623,7 +936,9 @@ class TestQuantityConverterSympy(unittest.TestCase):
         """
 
         self.assertEqual(
-            QuantityConverterSympy.activity_to_number(Integer(1), (Integer(625) * log(2)) / Integer(242988330816)),
+            QuantityConverterSympy.activity_to_number(
+                Integer(1), (Integer(625) * log(2)) / Integer(242988330816)
+            ),
             Integer(242988330816) / (Integer(625) * log(2)),
         )
 
@@ -633,13 +948,19 @@ class TestQuantityConverterSympy(unittest.TestCase):
         """
 
         self.assertEqual(
-            QuantityConverterSympy.mass_to_number(Integer(1), Integer("15055351900000000000000000000000000") / Integer(75401232033)),
+            QuantityConverterSympy.mass_to_number(
+                Integer(1),
+                Integer("15055351900000000000000000000000000") / Integer(75401232033),
+            ),
             Integer(75401232033)
             / Integer("15055351900000000000000000000000000")
             * Integer("602214076000000000000000"),
         )
         self.assertEqual(
-            QuantityConverterSympy.mass_to_number(Integer(1), Integer("60221407600000000000000000000000000") / Integer(301602932197)),
+            QuantityConverterSympy.mass_to_number(
+                Integer(1),
+                Integer("60221407600000000000000000000000000") / Integer(301602932197),
+            ),
             Integer(301602932197)
             / Integer("60221407600000000000000000000000000")
             * Integer("602214076000000000000000"),
@@ -651,7 +972,8 @@ class TestQuantityConverterSympy(unittest.TestCase):
         """
 
         self.assertEqual(
-            QuantityConverterSympy.moles_to_number(Integer(1)), Integer("602214076000000000000000")
+            QuantityConverterSympy.moles_to_number(Integer(1)),
+            Integer("602214076000000000000000"),
         )
         self.assertEqual(QuantityConverterSympy.moles_to_number(Integer(0)), Integer(0))
 
@@ -661,11 +983,21 @@ class TestQuantityConverterSympy(unittest.TestCase):
         """
 
         self.assertEqual(
-            QuantityConverterSympy.number_to_activity(Integer(1), (Integer(625) * log(2)) / Integer(242988330816)),
-            Integer(625) * log(2) / Integer(242988330816), 
+            QuantityConverterSympy.number_to_activity(
+                Integer(1), (Integer(625) * log(2)) / Integer(242988330816)
+            ),
+            Integer(625) * log(2) / Integer(242988330816),
         )
-        self.assertEqual(QuantityConverterSympy.number_to_activity(Integer(0), (Integer(625) * log(2)) / Integer(242988330816)), Integer(0))
-        self.assertEqual(QuantityConverterSympy.number_to_activity(Integer(0), Integer(0)), Integer(0))
+        self.assertEqual(
+            QuantityConverterSympy.number_to_activity(
+                Integer(0), (Integer(625) * log(2)) / Integer(242988330816)
+            ),
+            Integer(0),
+        )
+        self.assertEqual(
+            QuantityConverterSympy.number_to_activity(Integer(0), Integer(0)),
+            Integer(0),
+        )
 
     def test_number_to_mass(self) -> None:
         """
@@ -673,13 +1005,19 @@ class TestQuantityConverterSympy(unittest.TestCase):
         """
 
         self.assertEqual(
-            QuantityConverterSympy.number_to_mass(Integer(1), Integer("15055351900000000000000000000000000") / Integer(75401232033)),
+            QuantityConverterSympy.number_to_mass(
+                Integer(1),
+                Integer("15055351900000000000000000000000000") / Integer(75401232033),
+            ),
             Integer("15055351900000000000000000000000000")
             / Integer(75401232033)
             / Integer("602214076000000000000000"),
         )
         self.assertEqual(
-            QuantityConverterSympy.number_to_mass(Integer(1), Integer("60221407600000000000000000000000000") / Integer(301602932197)),
+            QuantityConverterSympy.number_to_mass(
+                Integer(1),
+                Integer("60221407600000000000000000000000000") / Integer(301602932197),
+            ),
             Integer("60221407600000000000000000000000000")
             / Integer(301602932197)
             / Integer("602214076000000000000000"),
@@ -691,7 +1029,8 @@ class TestQuantityConverterSympy(unittest.TestCase):
         """
 
         self.assertEqual(
-            QuantityConverterSympy.number_to_moles(Integer("602214076000000000000000")), Integer(1)
+            QuantityConverterSympy.number_to_moles(Integer("602214076000000000000000")),
+            Integer(1),
         )
         self.assertEqual(QuantityConverterSympy.number_to_moles(Integer(0)), Integer(0))
 
@@ -701,7 +1040,8 @@ class TestQuantityConverterSympy(unittest.TestCase):
         """
 
         self.assertEqual(
-            QuantityConverterSympy.__repr__(), "QuantityConverterSympy using SymPy arbitrary precision calculations."
+            QuantityConverterSympy.__repr__(),
+            "QuantityConverterSympy using SymPy arbitrary precision calculations.",
         )
 
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -76,15 +76,15 @@ class TestUnitConverterFloat(unittest.TestCase):
         )
         self.assertEqual(
             UnitConverterFloat.time_unit_conv(1.0, "s", "h", year_conv),
-            1.0 / (60.0 ** 2),
+            1.0 / (60.0**2),
         )
         self.assertEqual(
             UnitConverterFloat.time_unit_conv(1.0, "s", "d", year_conv),
-            1.0 / (60.0 ** 2 * 24.0),
+            1.0 / (60.0**2 * 24.0),
         )
         self.assertEqual(
             UnitConverterFloat.time_unit_conv(1.0, "s", "y", year_conv),
-            1.0 / (60.0 ** 2 * 24.0 * year_conv),
+            1.0 / (60.0**2 * 24.0 * year_conv),
         )
         self.assertAlmostEqual(
             UnitConverterFloat.time_unit_conv(1.0, "ps", "s", year_conv),
@@ -109,15 +109,15 @@ class TestUnitConverterFloat(unittest.TestCase):
             UnitConverterFloat.time_unit_conv(1.0, "m", "s", year_conv), 60.0
         )
         self.assertEqual(
-            UnitConverterFloat.time_unit_conv(1.0, "h", "s", year_conv), (60.0 ** 2)
+            UnitConverterFloat.time_unit_conv(1.0, "h", "s", year_conv), (60.0**2)
         )
         self.assertEqual(
             UnitConverterFloat.time_unit_conv(1.0, "d", "s", year_conv),
-            (60.0 ** 2 * 24.0),
+            (60.0**2 * 24.0),
         )
         self.assertEqual(
             UnitConverterFloat.time_unit_conv(1.0, "y", "s", year_conv),
-            (60.0 ** 2 * 24.0 * year_conv),
+            (60.0**2 * 24.0 * year_conv),
         )
 
         # Catch some incorrect time units

--- a/tests/test_decaydata.py
+++ b/tests/test_decaydata.py
@@ -244,7 +244,7 @@ class TestDecayData(unittest.TestCase):
         modes = np.array([["\u03b2+"], []], dtype=object)
         nuclides = np.array(["A-2", "B-1"])
         progeny = np.array([["B-1"], []], dtype=object)
-        float_unit_converter = converters.UnitConverterFloat(365.2422)
+        float_year_conv = 365.2422
 
         atomic_masses = np.array([0.0] * 2)
         decay_consts = np.array([0.0] * 2)
@@ -257,12 +257,12 @@ class TestDecayData(unittest.TestCase):
         dataset = decaydata.DecayData(
             dataset_name,
             bfs,
+            float_year_conv,
             hldata,
             modes,
             nuclides,
             progeny,
             decay_mats,
-            float_unit_converter,
         )
 
         self.assertEqual(dataset.dataset_name, "test_dataset")
@@ -282,12 +282,10 @@ class TestDecayData(unittest.TestCase):
         self.assertEqual(dataset.progeny[-1], [])
         self.assertEqual(dataset.bfs[-1], [])
         self.assertEqual(dataset.modes[-1], [])
-        self.assertEqual(
-            dataset.float_unit_converter, converters.UnitConverterFloat(365.2422)
-        )
+        self.assertEqual(dataset.float_year_conv, 365.2422)
         self.assertIsNotNone(dataset.float_quantity_converter)
         self.assertIsNone(dataset.sympy_data)
-        self.assertIsNone(dataset.sympy_unit_converter)
+        self.assertIsNone(dataset.sympy_year_conv)
         self.assertIsNone(dataset.sympy_quantity_converter)
 
         atomic_masses_sympy = Matrix.zeros(2, 1)
@@ -299,24 +297,22 @@ class TestDecayData(unittest.TestCase):
         decay_mats_sympy = decaydata.DecayMatricesSympy(
             atomic_masses_sympy, decay_consts_sympy, matrix_c_sympy, matrix_c_inv_sympy
         )
-        sympy_unit_converter = converters.UnitConverterSympy(
-            Integer(3652422) / Integer(1000)
-        )
+        sympy_year_conv = Integer(3652422) / Integer(1000)
 
         dataset = decaydata.DecayData(
             dataset_name,
             bfs,
+            float_year_conv,
             hldata,
             modes,
             nuclides,
             progeny,
             decay_mats,
-            float_unit_converter,
             decay_mats_sympy,
-            sympy_unit_converter,
+            sympy_year_conv
         )
         self.assertIsNotNone(dataset.sympy_data)
-        self.assertIsNotNone(dataset.sympy_unit_converter)
+        self.assertIsNotNone(dataset.sympy_year_conv)
         self.assertIsNotNone(dataset.sympy_quantity_converter)
 
     def test_half_life(self) -> None:

--- a/tests/test_decaydata.py
+++ b/tests/test_decaydata.py
@@ -7,7 +7,7 @@ import numpy as np
 from scipy import sparse
 from sympy import Integer, log, Matrix
 from sympy.matrices import SparseMatrix
-from radioactivedecay import converters, decaydata, icrp107_ame2020_nubase2020
+from radioactivedecay import decaydata, icrp107_ame2020_nubase2020
 
 
 class TestFunctions(unittest.TestCase):
@@ -283,10 +283,8 @@ class TestDecayData(unittest.TestCase):
         self.assertEqual(dataset.bfs[-1], [])
         self.assertEqual(dataset.modes[-1], [])
         self.assertEqual(dataset.float_year_conv, 365.2422)
-        self.assertIsNotNone(dataset.float_quantity_converter)
         self.assertIsNone(dataset.sympy_data)
         self.assertIsNone(dataset.sympy_year_conv)
-        self.assertIsNone(dataset.sympy_quantity_converter)
 
         atomic_masses_sympy = Matrix.zeros(2, 1)
         decay_consts_sympy = Matrix.zeros(2, 1)
@@ -313,7 +311,6 @@ class TestDecayData(unittest.TestCase):
         )
         self.assertIsNotNone(dataset.sympy_data)
         self.assertIsNotNone(dataset.sympy_year_conv)
-        self.assertIsNotNone(dataset.sympy_quantity_converter)
 
     def test_half_life(self) -> None:
         """

--- a/tests/test_decaydata.py
+++ b/tests/test_decaydata.py
@@ -307,7 +307,7 @@ class TestDecayData(unittest.TestCase):
             progeny,
             decay_mats,
             decay_mats_sympy,
-            sympy_year_conv
+            sympy_year_conv,
         )
         self.assertIsNotNone(dataset.sympy_data)
         self.assertIsNotNone(dataset.sympy_year_conv)

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -35,7 +35,6 @@ class TestInventory(unittest.TestCase):
         self.assertEqual(inv.contents, {"H-3": 1})
         self.assertEqual(inv.decay_data, DEFAULTDATA)
         self.assertEqual(inv.decay_matrices, DEFAULTDATA.scipy_data)
-        self.assertEqual(inv.quantity_converter, DEFAULTDATA.float_quantity_converter)
 
         # check instantiation using Nuclide instance
         tritium = Nuclide("H3")
@@ -101,31 +100,30 @@ class TestInventory(unittest.TestCase):
         """
 
         inv = Inventory({"H3": 1}, "num", True)
-        qconv = DEFAULTDATA.float_quantity_converter
         self.assertEqual(
-            inv._convert_to_number({"H-3": 1.0}, "num", qconv),
+            inv._convert_to_number({"H-3": 1.0}, "num"),
             {"H-3": 1.0},
         )
         self.assertEqual(
-            inv._convert_to_number({"H-3": 1.0}, "Bq", qconv),
+            inv._convert_to_number({"H-3": 1.0}, "Bq"),
             {"H-3": 560892895.7794082},
         )
         self.assertEqual(
-            inv._convert_to_number({"H-3": 1.0}, "mBq", qconv),
+            inv._convert_to_number({"H-3": 1.0}, "mBq"),
             {"H-3": 560892.8957794083},
         )
         self.assertEqual(
-            inv._convert_to_number({"H-3": 1.0}, "mol", qconv),
+            inv._convert_to_number({"H-3": 1.0}, "mol"),
             {"H-3": 6.02214076e23},
         )
         self.assertEqual(
-            inv._convert_to_number({"He-3": 1.0}, "kg", qconv),
+            inv._convert_to_number({"He-3": 1.0}, "kg"),
             {"He-3": 1.9967116089131648e26},
         )
 
         # check catch of incorrect units
         with self.assertRaises(ValueError):
-            inv._convert_to_number({"H-3": 1.0}, "xyz", qconv)
+            inv._convert_to_number({"H-3": 1.0}, "xyz")
 
     def test_nuclides(self) -> None:
         """
@@ -674,13 +672,9 @@ class TestInventoryHP(unittest.TestCase):
         )
         self.assertEqual(inv.decay_data, DEFAULTDATA)
         self.assertEqual(inv.decay_matrices, DEFAULTDATA.sympy_data)
-        self.assertEqual(inv.quantity_converter, DEFAULTDATA.sympy_quantity_converter)
 
         temp_data = copy.deepcopy(DEFAULTDATA)
         temp_data.sympy_year_conv = None
-        with self.assertRaises(ValueError):
-            InventoryHP({"H3": 1}, "Bq", True, temp_data)
-        temp_data.sympy_quantity_converter = None
         with self.assertRaises(ValueError):
             InventoryHP({"H3": 1}, "Bq", True, temp_data)
         temp_data.sympy_data = None

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -6,6 +6,10 @@ import copy
 import unittest
 from unittest.mock import patch
 from sympy import Integer, log
+from radioactivedecay.converters import (
+    UnitConverterFloat,
+    UnitConverterSympy
+)
 from radioactivedecay.decaydata import load_dataset, DEFAULTDATA
 from radioactivedecay.inventory import (
     Inventory,
@@ -32,7 +36,6 @@ class TestInventory(unittest.TestCase):
         self.assertEqual(inv.decay_data, DEFAULTDATA)
         self.assertEqual(inv.decay_matrices, DEFAULTDATA.scipy_data)
         self.assertEqual(inv.quantity_converter, DEFAULTDATA.float_quantity_converter)
-        self.assertEqual(inv.unit_converter, DEFAULTDATA.float_unit_converter)
 
         # check instantiation using Nuclide instance
         tritium = Nuclide("H3")
@@ -97,32 +100,32 @@ class TestInventory(unittest.TestCase):
         Test that the contents dictionary values (amounts of each nuclide) are physical.
         """
 
+        inv = Inventory({"H3": 1}, "num", True)
         qconv = DEFAULTDATA.float_quantity_converter
-        uconv = DEFAULTDATA.float_unit_converter
         self.assertEqual(
-            Inventory._convert_to_number({"H-3": 1.0}, "num", qconv, uconv),
+            inv._convert_to_number({"H-3": 1.0}, "num", qconv),
             {"H-3": 1.0},
         )
         self.assertEqual(
-            Inventory._convert_to_number({"H-3": 1.0}, "Bq", qconv, uconv),
+            inv._convert_to_number({"H-3": 1.0}, "Bq", qconv),
             {"H-3": 560892895.7794082},
         )
         self.assertEqual(
-            Inventory._convert_to_number({"H-3": 1.0}, "mBq", qconv, uconv),
+            inv._convert_to_number({"H-3": 1.0}, "mBq", qconv),
             {"H-3": 560892.8957794083},
         )
         self.assertEqual(
-            Inventory._convert_to_number({"H-3": 1.0}, "mol", qconv, uconv),
+            inv._convert_to_number({"H-3": 1.0}, "mol", qconv),
             {"H-3": 6.02214076e23},
         )
         self.assertEqual(
-            Inventory._convert_to_number({"He-3": 1.0}, "kg", qconv, uconv),
+            inv._convert_to_number({"He-3": 1.0}, "kg", qconv),
             {"He-3": 1.9967116089131648e26},
         )
 
         # check catch of incorrect units
         with self.assertRaises(ValueError):
-            Inventory._convert_to_number({"H-3": 1.0}, "xyz", qconv, uconv)
+            inv._convert_to_number({"H-3": 1.0}, "xyz", qconv)
 
     def test_nuclides(self) -> None:
         """
@@ -672,10 +675,9 @@ class TestInventoryHP(unittest.TestCase):
         self.assertEqual(inv.decay_data, DEFAULTDATA)
         self.assertEqual(inv.decay_matrices, DEFAULTDATA.sympy_data)
         self.assertEqual(inv.quantity_converter, DEFAULTDATA.sympy_quantity_converter)
-        self.assertEqual(inv.unit_converter, DEFAULTDATA.sympy_unit_converter)
 
         temp_data = copy.deepcopy(DEFAULTDATA)
-        temp_data.sympy_unit_converter = None
+        temp_data.sympy_year_conv = None
         with self.assertRaises(ValueError):
             InventoryHP({"H3": 1}, "Bq", True, temp_data)
         temp_data.sympy_quantity_converter = None

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -6,10 +6,6 @@ import copy
 import unittest
 from unittest.mock import patch
 from sympy import Integer, log
-from radioactivedecay.converters import (
-    UnitConverterFloat,
-    UnitConverterSympy
-)
 from radioactivedecay.decaydata import load_dataset, DEFAULTDATA
 from radioactivedecay.inventory import (
     Inventory,

--- a/tests/test_nuclide.py
+++ b/tests/test_nuclide.py
@@ -16,28 +16,21 @@ class TestNuclide(unittest.TestCase):
         """
         Test instantiation of Nuclide objects.
         """
+        decay_data = load_dataset("icrp107_ame2020_nubase2020", load_sympy=True)
 
         nuc = Nuclide("Rn-222")
         self.assertEqual(nuc.nuclide, "Rn-222")
-        self.assertEqual(nuc.prog, ["Po-218"])
-        self.assertEqual(nuc.bfs, [1.0])
-        self.assertEqual(nuc.modes, ["\u03b1"])
+        self.assertEqual(nuc.decay_data, decay_data)
 
         nuc = Nuclide("222Rn")
         self.assertEqual(nuc.nuclide, "Rn-222")
-        self.assertEqual(nuc.prog, ["Po-218"])
-        self.assertEqual(nuc.bfs, [1.0])
-        self.assertEqual(nuc.modes, ["\u03b1"])
 
         nuc = Nuclide(611450000)
         self.assertEqual(nuc.nuclide, "Pm-145")
-        self.assertEqual(nuc.prog, ["Nd-145", "Pr-141"])
-        self.assertEqual(nuc.bfs, [1.0, 2.8e-09])
-        self.assertEqual(nuc.modes, ["EC", "\u03b1"])
 
     def test_nuclide_Z(self) -> None:
         """
-        Test Nuclide Z attribute.
+        Test Nuclide Z property.
         """
 
         nuc = Nuclide("H-3")
@@ -45,15 +38,29 @@ class TestNuclide(unittest.TestCase):
 
     def test_nuclide_A(self) -> None:
         """
-        Test Nuclide A attribute.
+        Test Nuclide A property.
         """
 
         nuc = Nuclide("H-3")
         self.assertEqual(nuc.A, 3)
 
+    def test_nuclide_state(self) -> None:
+        """
+        Test Nuclide state property.
+        """
+
+        nuc = Nuclide("H-3")
+        self.assertEqual(nuc.state, "")
+
+        nuc = Nuclide("Ba-137m")
+        self.assertEqual(nuc.state, "m")
+
+        nuc = Nuclide("Ir-192n")
+        self.assertEqual(nuc.state, "n")
+
     def test_nuclide_id(self) -> None:
         """
-        Test Nuclide id attribute.
+        Test Nuclide id property.
         """
 
         nuc = Nuclide("H-3")
@@ -65,7 +72,15 @@ class TestNuclide(unittest.TestCase):
         nuc = Nuclide(190400000)
         self.assertEqual(nuc.id, 190400000)
 
-    def test_radionuclide_half_life(self) -> None:
+    def test_nuclide_atomic_mass(self) -> None:
+        """
+        Test Nuclide atomic_mass property.
+        """
+
+        nuc = Nuclide("H-3")
+        self.assertEqual(nuc.atomic_mass, 3.01604928132)
+
+    def test_nuclide_half_life(self) -> None:
         """
         Test Nuclide half_life() method.
         """
@@ -75,16 +90,16 @@ class TestNuclide(unittest.TestCase):
         self.assertEqual(nuc.half_life("y"), 12.32)
         self.assertEqual(nuc.half_life("readable"), "12.32 y")
 
-    def test_radionuclide_progeny(self) -> None:
+    def test_nuclide_progeny(self) -> None:
         """
-        Test Nuclide half_life() method.
+        Test Nuclide progeny() method.
         """
 
         nuc = Nuclide("K-40")
         self.assertEqual(nuc.progeny()[0], "Ca-40")
         self.assertEqual(nuc.progeny()[1], "Ar-40")
 
-    def test_radionuclide_branching_fractions(self) -> None:
+    def test_nuclide_branching_fractions(self) -> None:
         """
         Test Nuclide branching_fractions() method.
         """
@@ -93,7 +108,7 @@ class TestNuclide(unittest.TestCase):
         self.assertEqual(nuc.branching_fractions()[0], 0.8914)
         self.assertEqual(nuc.branching_fractions()[1], 0.1086)
 
-    def test_radionuclide_decay_modes(self) -> None:
+    def test_nuclide_decay_modes(self) -> None:
         """
         Test Nuclide decay_modes() method.
         """
@@ -102,7 +117,7 @@ class TestNuclide(unittest.TestCase):
         self.assertEqual(nuc.decay_modes()[0], "\u03b2-")
         self.assertEqual(nuc.decay_modes()[1], "\u03b2+ & EC")
 
-    def test_radionuclide_plot(self) -> None:
+    def test_nuclide_plot(self) -> None:
         """
         Test Nuclide plot() method.
 
@@ -129,7 +144,7 @@ class TestNuclide(unittest.TestCase):
         self.assertEqual(axes.get_xlim(), (-0.3, 1.3))
         self.assertEqual(axes.get_ylim(), (-1.3, 0.3))
 
-    def test_radionuclide___repr__(self) -> None:
+    def test_nuclide___repr__(self) -> None:
         """
         Test Nuclide __repr__ strings.
         """
@@ -157,7 +172,7 @@ class TestNuclide(unittest.TestCase):
 
         self.assertFalse(nuc1 == "random object")
 
-    def test_radionuclide___ne__(self) -> None:
+    def test_nuclide___ne__(self) -> None:
         """
         Test Nuclide inequality.
         """
@@ -168,7 +183,7 @@ class TestNuclide(unittest.TestCase):
 
         self.assertTrue(nuc1 != "random object")
 
-    def test_radionuclide___hash__(self) -> None:
+    def test_nuclide___hash__(self) -> None:
         """
         Test Nuclide hash function.
         """


### PR DESCRIPTION
#### What does this PR implement/fix?
This PR improves the underlying code quality by reducing the coupling between the different code components. It refactors the Converter & Nuclide classes to not store duplicate data, but to receive needed data only via their API calls. DecayData objects no longer need to store Converter objects. Continuing to reduce pylint/mypy errors/warnings, however will need to wait to bump requirement to Python 3.7+ to improve type hinting of NumPy/SciPy arrays (requires NumPy 1.21+, holding off for now to maintain Python 3.6 support).

#### Fixes Issue
N/A


#### Other comments?
Refactoring of DecayData storage classes to come next.