### PR TITLE
Fix incorrect parsing of SymPy version string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.10] - 2022-03-15
+- Fix incorrect parsing of SymPy version string (#67, #68). This bug meant radioactivedecay import
+failed if using SymPy >=1.10. The fix makes Setuptools an explicit dependency.
+
 ## [0.4.9] - 2022-02-07
 - Code refactoring: reduce coupling between modules by refactoring Converter, Nuclide & Inventory
 classes to not store duplicate data, but to receive data when needed via their API calls. DecayData objects

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ $ conda install -c conda-forge radioactivedecay
 ```
 
 Either command will attempt to install the dependencies (Matplotlib, NetworkX,
-NumPy, SciPy & SymPy) if they are not already present in the environment.
+NumPy, SciPy, Setuptools & SymPy) if they are not already present in the
+environment.
 
 
 ## Usage

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -7,7 +7,8 @@ Prerequisites
 ``radioactivedecay`` requires Python 3.6+ and the `Matplotlib
 <https://matplotlib.org/>`_, `NetworkX
 <https://networkx.org/>`_, `NumPy <https://numpy.org/>`_,
-`SciPy <https://www.scipy.org/index.html>`_  and 
+`SciPy <https://www.scipy.org/index.html>`_,
+`Setuptools <https://setuptools.pypa.io/en/latest/>`_ and 
 `SymPy <https://www.sympy.org>`_ packages. These can be
 installed from `python.org <https://www.python.org/>`_ and `PyPI
 <https://pypi.org/>`_, or via a package manager such as `Anaconda
@@ -32,7 +33,8 @@ or via `conda-forge <https://anaconda.org/conda-forge/radioactivedecay>`_:
     $ conda install -c conda-forge radioactivedecay
 
 Either command will attempt to install the dependencies (Matplotlib, NetworkX,
-NumPy, SciPy & SymPy) if they are not already present in the environment.
+NumPy, SciPy, Setuptools & SymPy) if they are not already present in the
+environment.
 
 It is also possible to clone the GitHub `repository 
 <https://github.com/radioactivedecay/radioactivedecay>`_ and install from within the

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -18,8 +18,9 @@ decay differential equations analytically using basic linear algebra operations
 :ref:`[5] <refs>`.
 
 In order to use ``radioactivedecay``, you will need Python 3.6+ with the
-Matplotlib, NetworkX, NumPy, SciPy and SymPy packages installed. The code is
-platform independent and has been tested on Windows, MacOS and Linux systems.
+Matplotlib, NetworkX, NumPy, SciPy, Setuptools and SymPy packages installed.
+The code is platform independent and has been tested on Windows, MacOS and
+Linux systems.
 
 Quick start
 -----------
@@ -37,7 +38,8 @@ or using ``conda`` by:
     $ conda install -c conda-forge radioactivedecay
 
 Either command will attempt to install the dependencies (Matplotlib, NetworkX,
-NumPy, SciPy & SymPy) if they are not already present in the environment.
+NumPy, SciPy, Setuptooks & SymPy) if they are not already present in the
+environment.
 
 Import the ``radioactivedecay`` package and decay a simple inventory using:
 
@@ -229,6 +231,7 @@ Special thanks to:
 * `Wolfgang Kerzendorf <https://wkerzendorf.github.io/>`_
 * `Hunter Ratliff <https://hratliff.com/>`_
 * `Jayson Vavrek <https://github.com/jvavrek>`_
+* `radioactivedecay-github <https://github.com/radioactivedecay-github>`_
 
 for suggestions, support and assistance to this project.
 

--- a/radioactivedecay/__init__.py
+++ b/radioactivedecay/__init__.py
@@ -25,7 +25,7 @@ imported as ``rd``:
 
 """
 
-__version__ = "0.4.9"
+__version__ = "0.4.10"
 
 from radioactivedecay.decaydata import DecayData, DEFAULTDATA
 from radioactivedecay.inventory import Inventory, InventoryHP

--- a/radioactivedecay/decaydata.py
+++ b/radioactivedecay/decaydata.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import pickle
 from typing import Any, ContextManager, Optional, Union
 import numpy as np
+import pkg_resources
 from scipy import sparse
 import sympy
 from sympy import Matrix
@@ -763,7 +764,12 @@ def load_dataset(
     sympy_data = None
     sympy_year_conv = None
     if load_sympy:
-        sympy_pickle_version = "1.9" if sympy.__version__ >= "1.9" else "1.8"
+        sympy_pickle_version = (
+            "1.8"
+            if pkg_resources.parse_version(sympy.__version__)
+            < pkg_resources.parse_version("1.9")
+            else "1.9"
+        )
 
         atomic_masses = _load_pickle_file(
             dataset_name, dir_path, f"atomic_masses_sympy_{sympy_pickle_version}.pickle"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ matplotlib
 networkx
 numpy
 scipy
+setuptools
 sympy
 importlib_resources; python_version<'3.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ install_requires =
     networkx
     numpy
     scipy
+    setuptools
     sympy
     importlib_resources; python_version<'3.7'
 


### PR DESCRIPTION
#### What does this PR implement/fix?

Fixes a bug which affected the parsing and utilization of SymPy version strings. The bug caused `radioactivedecay` import to fail with the latest release of SymPy (v1.10, released on Mar 7, 2022).

This PR devolves responsibility for comparing SymPy version strings to the `pkg_resources` module within [Setuptools](https://setuptools.pypa.io/en/latest/pkg_resources.html). This should mean fully PEP 440 compliant comparisons between SymPy version strings, and hopefully stop failures like this occurring again.

Setuptools becomes an explicit dependency of this project.

#### Fixes Issue
#67 


#### Other comments?
Thanks to @radioactivedecay-github for reporting this issue.
