### PR TITLE
Fix load_dataset() docstring not showing in API docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.X.X] - 20XX-XX-XX
+- Fix `load_dataset()` docstring not showing in decaydata API docpage (#71).
+
 ## [0.4.10] - 2022-03-15
 - Fix incorrect parsing of SymPy version string (#67, #68). This bug meant radioactivedecay import
 failed if using SymPy >=1.10. The fix makes Setuptools an explicit dependency.

--- a/docs/source/decaydata.rst
+++ b/docs/source/decaydata.rst
@@ -2,6 +2,7 @@ decaydata
 =========
 
 .. automodule:: radioactivedecay.decaydata
+   :members: load_dataset
 
 DecayData
 ---------

--- a/radioactivedecay/decaydata.py
+++ b/radioactivedecay/decaydata.py
@@ -715,8 +715,8 @@ def load_dataset(
     dataset_name: str, dir_path: Optional[str] = None, load_sympy: bool = False
 ) -> DecayData:
     """
-    Load a decay dataset, either from a set of data files within a sub-packaged of
-    ``radioactivedecay``, or by specifying a local directory containing the data files.
+    Load a decay dataset, either from a set of data files packaged within ``radioactivedecay``,
+    or by specifying a local directory containing the data files.
 
     Parameters
     ----------


### PR DESCRIPTION
#### What does this PR implement/fix?
Docstring for `load_dataset()` in `decaydata` module was not showing up in the API docs.

#### Fixes Issue
Pertinent to discussion #70 


#### Other comments?
