### PR TITLE
Fixes decay plot log ymin nuclide string parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [0.X.X] - 20XX-XX-XX
+## [0.4.11] - 2022-03-20
+- Default `ymin` for Inventory `plot()` method is now 0.95x the minimum quantity that occurs over
+the decay period when `yscale='log'` (#70 & #72).
+- Improved nuclide string parsing: robust to nuclide strings containing whitespaces and some
+incorrect capitalizations of the element / metastable state chars (#65 & #72).
 - Fix `load_dataset()` docstring not showing in decaydata API docpage (#71).
 
 ## [0.4.10] - 2022-03-15

--- a/radioactivedecay/__init__.py
+++ b/radioactivedecay/__init__.py
@@ -25,7 +25,7 @@ imported as ``rd``:
 
 """
 
-__version__ = "0.4.10"
+__version__ = "0.4.11"
 
 from radioactivedecay.decaydata import DecayData, DEFAULTDATA
 from radioactivedecay.inventory import Inventory, InventoryHP

--- a/radioactivedecay/inventory.py
+++ b/radioactivedecay/inventory.py
@@ -837,7 +837,8 @@ class AbstractInventory(ABC):
         yscale : str, optional
             The y-axis scale type to apply ('linear' or 'log', default is 'linear').
         ymin : float, optional
-            Minimum value for the y-axis (default is 0.0 for linear y-axis, 0.1 for log y-axis).
+            Minimum value for the y-axis (default is 0.0 for ``yscale='linear'``, or 0.95x the
+            minimum quantity that occurs over the decay period for ``yscale='log'``).
         ymax : None or float, optional
             Maximum value for the y-axis. Default is None, which sets the limit to 1.05x the
             maximum quantity that occurs over the decay period.
@@ -851,9 +852,9 @@ class AbstractInventory(ABC):
             Default is 'all', which displays all nuclides present upon decay of the inventory.
         order : str, optional
             Order to display the nuclide decay curves on the graph if you do not specify the
-            order via the display parameter. Default order is by "dataset", which follows the order
+            order via the display parameter. Default order is by 'dataset', which follows the order
             of the nuclides in the decay dataset (highest to lowest nuclides in the decay
-            chains). Use "alphabetical" if you want the nuclides to be ordered alphabetically.
+            chains). Use 'alphabetical' if you want the nuclides to be ordered alphabetically.
         npoints : None or int, optional
             Number of time points used to plot graph (default is 501 for normal precision decay
             calculations, or 51 for high precision decay calculations).
@@ -952,7 +953,7 @@ class AbstractInventory(ABC):
             raise ValueError(f"{yunits} is not a supported y-axes unit.")
 
         if yscale == "log" and ymin == 0.0:
-            ymin = 0.1
+            ymin = 0.95 * ydata.min()
         ylimits = [ymin, ymax] if ymax else [ymin, 1.05 * ydata.max()]
 
         fig, axes = decay_graph(
@@ -1527,13 +1528,14 @@ class InventoryHP(AbstractInventory):
         yscale : str, optional
             The y-axis scale type to apply ('linear' or 'log', default is 'linear').
         ymin : float, optional
-            Minimum value for the y-axis (default is 0.0 for linear y-axis, 0.1 for log y-axis).
+            Minimum value for the y-axis (default is 0.0 for ``yscale='linear'``, or 0.95x the
+            minimum quantity that occurs over the decay period for ``yscale='log'``).
         ymax : None or float, optional
             Maximum value for the y-axis. Default is None, which sets the limit to 1.05x the
             maximum quantity that occurs over the decay period.
         yunits : str, optional
             Units to display on the y-axis e.g. 'Bq', 'kBq', 'Ci', 'g', 'mol', 'num',
-            'mass_frac', 'mol_frac'. Default is 'Bq'.
+            'activity_frac', 'mass_frac', 'mol_frac'. Default is 'Bq'.
         display : str or list, optional
             Only display the nuclides within this list on the graph. Use this parameter when
             you want to choose specific nuclide decay curves shown on the graph, either by
@@ -1541,9 +1543,9 @@ class InventoryHP(AbstractInventory):
             Default is 'all', which displays all nuclides present upon decay of the inventory.
         order : str, optional
             Order to display the nuclide decay curves on the graph if you do not specify the
-            order via the display parameter. Default order is by "dataset", which follows the order
+            order via the display parameter. Default order is by 'dataset', which follows the order
             of the nuclides in the decay dataset (highest to lowest nuclides in the decay
-            chains). Use "alphabetical" if you want the nuclides to be ordered alphabetically.
+            chains). Use 'alphabetical' if you want the nuclides to be ordered alphabetically.
         npoints : None or int, optional
             Number of time points used to plot graph. Default is 51.
         fig : None or matplotlib.figure.Figure, optional

--- a/radioactivedecay/utils.py
+++ b/radioactivedecay/utils.py
@@ -294,6 +294,8 @@ def parse_nuclide_str(nuclide: str) -> str:
 
     """
 
+    nuclide = "".join(nuclide.split())  # Remove all whitespaces (Issue #65).
+
     letter_flag, number_flag = False, False
     for char in nuclide:
         if char.isalpha():
@@ -316,6 +318,11 @@ def parse_nuclide_str(nuclide: str) -> str:
             if nuclide[idx - 1] != "-":
                 nuclide = f"{nuclide[:idx]}-{nuclide[idx:]}"
             break
+    
+    # Convert incorrect capitalizations, e.g. tc-99M to Tc-99m, tC-99m to Tc-99m (Issue #65).
+    # Note 99MTc will fail because above logic requires metastable state char is lower case.
+    if nuclide[0].islower() or nuclide[1].isupper() or nuclide[-1].isupper():
+        nuclide = nuclide[0].upper() + nuclide[1].lower() + nuclide[2:-1] + nuclide[-1].lower()
 
     return nuclide
 

--- a/radioactivedecay/utils.py
+++ b/radioactivedecay/utils.py
@@ -318,11 +318,16 @@ def parse_nuclide_str(nuclide: str) -> str:
             if nuclide[idx - 1] != "-":
                 nuclide = f"{nuclide[:idx]}-{nuclide[idx:]}"
             break
-    
+
     # Convert incorrect capitalizations, e.g. tc-99M to Tc-99m, tC-99m to Tc-99m (Issue #65).
     # Note 99MTc will fail because above logic requires metastable state char is lower case.
     if nuclide[0].islower() or nuclide[1].isupper() or nuclide[-1].isupper():
-        nuclide = nuclide[0].upper() + nuclide[1].lower() + nuclide[2:-1] + nuclide[-1].lower()
+        nuclide = (
+            nuclide[0].upper()
+            + nuclide[1].lower()
+            + nuclide[2:-1]
+            + nuclide[-1].lower()
+        )
 
     return nuclide
 

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -863,7 +863,7 @@ class TestInventoryHP(unittest.TestCase):
         self.assertEqual(axes.get_xlabel(), "Time (s)")
         self.assertEqual(axes.get_ylabel(), "Number of moles (mmol)")
         self.assertEqual(axes.get_xlim()[0], 0.0707945784384138)
-        self.assertEqual(axes.get_ylim(), (0.1, 2100.0))
+        self.assertEqual(axes.get_ylim(), (949.999999633917, 2100.0))
         self.assertEqual(axes.get_legend_handles_labels()[-1], ["K-40", "C-14"])
 
     def test___repr__(self) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -87,6 +87,25 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(parse_nuclide_str("Ca40"), "Ca-40")
         self.assertEqual(parse_nuclide_str("40Ca"), "Ca-40")
 
+        # Whitespace removal (Issue #65)
+        self.assertEqual(parse_nuclide_str(" Ca -40 "), "Ca-40")
+        self.assertEqual(parse_nuclide_str("C\ta\n-40"), "Ca-40")
+
+        # Robust to capitalization mistakes (Issue #65)
+        self.assertEqual(parse_nuclide_str("y-91"), "Y-91")
+        self.assertEqual(parse_nuclide_str("y91"), "Y-91")
+        self.assertEqual(parse_nuclide_str("91y"), "Y-91")
+        self.assertEqual(parse_nuclide_str("y-91M"), "Y-91m")
+        self.assertEqual(parse_nuclide_str("y91M"), "Y-91m")
+        self.assertEqual(parse_nuclide_str("91my"), "Y-91m")
+        self.assertEqual(parse_nuclide_str("ca-40"), "Ca-40")
+        self.assertEqual(parse_nuclide_str("CA-40"), "Ca-40")
+        self.assertEqual(parse_nuclide_str("Tc-99M"), "Tc-99m")
+        self.assertEqual(parse_nuclide_str("iR192N"), "Ir-192n")
+        # Note following test won't work as need to metastable char to be lower case for it to be
+        # identified as a metastable char not an element char:
+        #self.assertEqual(parse_nuclide_str("192NiR"), "Ir-192n")
+
     def test_parse_nuclide(self) -> None:
         """
         Test the parsing of nuclide strings.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,7 +104,7 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(parse_nuclide_str("iR192N"), "Ir-192n")
         # Note following test won't work as need to metastable char to be lower case for it to be
         # identified as a metastable char not an element char:
-        #self.assertEqual(parse_nuclide_str("192NiR"), "Ir-192n")
+        # self.assertEqual(parse_nuclide_str("192NiR"), "Ir-192n")
 
     def test_parse_nuclide(self) -> None:
         """


### PR DESCRIPTION
#### What does this PR implement/fix?
- Default `ymin` for Inventory `plot()` method is now 0.95x the minimum quantity that occurs over the decay period when `yscale='log'`.
- Improved nuclide string parsing: robust to nuclide strings containing whitespaces and some incorrect capitalizations of the element / metastable state chars.

#### Fixes Issue
Discussion #70: no data showing on Inventory `plot()` when using `yscale='log'` if the maximum quantity of any nuclide over the decay period is less than 0.1.

Issue #65: improvements to nuclide string parsing to cope with strings that contain whitespaces or non-standard capitalizations of the element / metastable state characters.

#### Other comments?

The fix for issue #65 is not perfect. It will not work with the string `'99MTc'` (i.e. Tc-99m). This is because the logic assumes the metastable state character will be lower case. Capital M/N could mean an element starting with these chars, e.g. Mg or Na, so cumbersome logic would be required to fix this case.

Note however `'Tc-99M'` or `'Tc99M'` will be parsed correctly. This is because the numbers can be used to delineate between the element characters and the metastable state character.
