### PR TITLE
Improve metastable char processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [0.X.XX] - 20XX-XX-XX
-- Code improvement to support metastable states up to 5th state (#76).
+- Code improvement to support metastable states up to 6th state (#76).
 
 ## [0.4.12] - 2022-3-24
 - Added more stable products to the default ICRP-107 dataset (#75).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.X.XX] - 20XX-XX-XX
+- Code improvement to support metastable states up to 5th state (#76).
+
 ## [0.4.12] - 2022-3-24
 - Added more stable products to the default ICRP-107 dataset (#75).
 

--- a/radioactivedecay/__init__.py
+++ b/radioactivedecay/__init__.py
@@ -25,7 +25,7 @@ imported as ``rd``:
 
 """
 
-__version__ = "0.4.12"
+__version__ = "0.4.13"
 
 from radioactivedecay.decaydata import DecayData, DEFAULTDATA
 from radioactivedecay.inventory import Inventory, InventoryHP

--- a/radioactivedecay/plots.py
+++ b/radioactivedecay/plots.py
@@ -47,7 +47,9 @@ def _parse_nuclide_label(nuclide: str) -> str:
         "9": "\N{SUPERSCRIPT NINE}",
         "m": "\N{MODIFIER LETTER SMALL M}",
         "n": "\N{SUPERSCRIPT LATIN SMALL LETTER N}",
-        "o": "\N{MODIFIER LETTER SMALL O}",
+        "p": "\N{MODIFIER LETTER SMALL P}",
+        "q": "\N{LATIN SMALL LETTER Q}",  # Unicode has no superscript q
+        "r": "\N{MODIFIER LETTER SMALL R}",
     }
 
     element, isotope = nuclide.split("-")

--- a/radioactivedecay/plots.py
+++ b/radioactivedecay/plots.py
@@ -50,6 +50,7 @@ def _parse_nuclide_label(nuclide: str) -> str:
         "p": "\N{MODIFIER LETTER SMALL P}",
         "q": "\N{LATIN SMALL LETTER Q}",  # Unicode has no superscript q
         "r": "\N{MODIFIER LETTER SMALL R}",
+        "x": "\N{MODIFIER LETTER SMALL X}",
     }
 
     element, isotope = nuclide.split("-")

--- a/radioactivedecay/utils.py
+++ b/radioactivedecay/utils.py
@@ -137,18 +137,20 @@ Z_DICT = {
     118: "Og",
 }
 SYM_DICT = dict((v, k) for k, v in Z_DICT.items())
-METASTABLE_CHARS = ["m", "n", "p", "q", "r"]
+METASTABLE_CHARS = ["m", "n", "p", "q", "r", "x"]
 
 
 def get_metastable_chars() -> List[str]:
     """
-    Returns list of allowed metastable state characters. Currently up to fifth metastable state is
-    supported, based on the existence of fifth metastable state isomers in NUBASE2020, e.g.
-    Lu-177r.
+    Returns list of allowed metastable state characters. Currently up to sixth metastable state is
+    supported, based on the existence of sixth metastable state isomers in NUBASE2020, e.g.
+    Lu-174x.
 
-    Note metastable state chars are "m", "n", "p", "q", "r" for the first to fifth metastable
-    state, respectively, i.e. "o" is not a metastable state char. Ref. Kondev CPC NUBASE2020 paper.
+    Note metastable state chars are "m", "n", "p", "q", "r", "x" for the first to sixth metastable
+    state, respectively, i.e. "o" is not a metastable state char, nor letters between "r" and "x".
+    See NUBASE2020 paper (F.G. Kondev et al 2021 Chinese Phys. C 45 030001) for more details.
     """
+
     return METASTABLE_CHARS
 
 

--- a/radioactivedecay/utils.py
+++ b/radioactivedecay/utils.py
@@ -137,6 +137,19 @@ Z_DICT = {
     118: "Og",
 }
 SYM_DICT = dict((v, k) for k, v in Z_DICT.items())
+METASTABLE_CHARS = ["m", "n", "p", "q", "r"]
+
+
+def get_metastable_chars() -> List[str]:
+    """
+    Returns list of allowed metastable state characters. Currently up to fifth metastable state is
+    supported, based on the existence of fifth metastable state isomers in NUBASE2020, e.g.
+    Lu-177r.
+
+    Note metastable state chars are "m", "n", "p", "q", "r" for the first to fifth metastable
+    state, respectively, i.e. "o" is not a metastable state char. Ref. Kondev CPC NUBASE2020 paper.
+    """
+    return METASTABLE_CHARS
 
 
 def Z_to_elem(Z: int) -> str:
@@ -220,10 +233,8 @@ def build_id(Z: int, A: int, state: str = "") -> int:
     """
 
     if state != "":
-        if state == "m":
-            state_int = 1
-        elif state == "n":
-            state_int = 2
+        if state in get_metastable_chars():
+            state_int = get_metastable_chars().index(state) + 1
         else:
             raise ValueError(state + " is not a valid energy state.")
     else:
@@ -310,7 +321,7 @@ def parse_nuclide_str(nuclide: str) -> str:
 
     while nuclide[0].isdigit():  # Re-order inputs e.g. 99mTc to Tc99m.
         nuclide = nuclide[1:] + nuclide[0]
-    if nuclide[0] in ["m", "n"]:
+    if nuclide[0] in get_metastable_chars():
         nuclide = nuclide[1:] + nuclide[0]
 
     for idx in range(1, len(nuclide)):  # Add hyphen e.g. Tc99m to Tc-99m.
@@ -358,11 +369,7 @@ def parse_id(input_id: int) -> str:
 
     id_zzzaaa = int(input_id / 10000)
     state_digits = input_id - (id_zzzaaa * 10000)
-    state = ""
-    if state_digits == 1:
-        state = "m"
-    elif state_digits == 2:
-        state = "n"
+    state = get_metastable_chars()[state_digits - 1] if state_digits > 0 else ""
     Z = int(id_zzzaaa / 1000)
     A = id_zzzaaa - (Z * 1000)
     name = build_nuclide_string(Z, A, state)

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -35,6 +35,7 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(_parse_nuclide_label("In-129p"), "¹²⁹ᵖIn")
         self.assertEqual(_parse_nuclide_label("Lu-177q"), "¹⁷⁷qLu")
         self.assertEqual(_parse_nuclide_label("Lu-177r"), "¹⁷⁷ʳLu")
+        self.assertEqual(_parse_nuclide_label("Lu-174x"), "¹⁷⁴ˣLu")
         self.assertEqual(_parse_nuclide_label("SF"), "various")
 
     def test__parse_decay_mode_label(self) -> None:

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -32,6 +32,9 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(_parse_nuclide_label("I-118m"), "¹¹⁸ᵐI")
         self.assertEqual(_parse_nuclide_label("Tb-156m"), "¹⁵⁶ᵐTb")
         self.assertEqual(_parse_nuclide_label("Tb-156n"), "¹⁵⁶ⁿTb")
+        self.assertEqual(_parse_nuclide_label("In-129p"), "¹²⁹ᵖIn")
+        self.assertEqual(_parse_nuclide_label("Lu-177q"), "¹⁷⁷qLu")
+        self.assertEqual(_parse_nuclide_label("Lu-177r"), "¹⁷⁷ʳLu")
         self.assertEqual(_parse_nuclide_label("SF"), "various")
 
     def test__parse_decay_mode_label(self) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,7 +30,7 @@ class TestFunctions(unittest.TestCase):
         Test fetching of list of metastable state characters.
         """
 
-        self.assertEqual(get_metastable_chars(), ["m", "n", "p", "q", "r"])
+        self.assertEqual(get_metastable_chars(), ["m", "n", "p", "q", "r", "x"])
 
     def test_Z_to_elem(self) -> None:
         """
@@ -62,6 +62,7 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(build_id(49, 129, "p"), 491290003)
         self.assertEqual(build_id(71, 177, "q"), 711770004)
         self.assertEqual(build_id(71, 177, "r"), 711770005)
+        self.assertEqual(build_id(71, 174, "x"), 711740006)
 
         with self.assertRaises(ValueError):
             build_id(65, 156, "z")
@@ -78,6 +79,7 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(build_nuclide_string(49, 129, "p"), "In-129p")
         self.assertEqual(build_nuclide_string(71, 177, "q"), "Lu-177q")
         self.assertEqual(build_nuclide_string(71, 177, "r"), "Lu-177r")
+        self.assertEqual(build_nuclide_string(71, 174, "x"), "Lu-174x")
 
         with self.assertRaises(ValueError):
             build_nuclide_string(999, 1000, "z")
@@ -112,6 +114,7 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(parse_nuclide_str("iN129P"), "In-129p")
         self.assertEqual(parse_nuclide_str("177qLu"), "Lu-177q")
         self.assertEqual(parse_nuclide_str("LU177R"), "Lu-177r")
+        self.assertEqual(parse_nuclide_str("lu-174x"), "Lu-174x")
 
     def test_parse_id(self) -> None:
         """
@@ -125,6 +128,7 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(parse_id(491290003), "In-129p")
         self.assertEqual(parse_id(711770004), "Lu-177q")
         self.assertEqual(parse_id(711770005), "Lu-177r")
+        self.assertEqual(parse_id(711740006), "Lu-174x")
 
     def test_parse_nuclide(self) -> None:
         """
@@ -146,6 +150,7 @@ class TestFunctions(unittest.TestCase):
                 "In-129p",
                 "Lu-177q",
                 "Lu-177r",
+                "Lu-174x",
             ]
         )
         dataset_name = "test"
@@ -203,6 +208,10 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(parse_nuclide("Lu-177r", nuclides, dataset_name), "Lu-177r")
         self.assertEqual(parse_nuclide("177rLu", nuclides, dataset_name), "Lu-177r")
         self.assertEqual(parse_nuclide(711770005, nuclides, dataset_name), "Lu-177r")
+        self.assertEqual(parse_nuclide("Lu-174x", nuclides, dataset_name), "Lu-174x")
+        self.assertEqual(parse_nuclide("Lu-174x", nuclides, dataset_name), "Lu-174x")
+        self.assertEqual(parse_nuclide("174xLu", nuclides, dataset_name), "Lu-174x")
+        self.assertEqual(parse_nuclide(711740006, nuclides, dataset_name), "Lu-174x")
 
         # Catch erroneous strings
         with self.assertRaises(TypeError):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,12 +6,13 @@ import unittest
 import numpy as np
 from sympy import Integer, log
 from radioactivedecay.utils import (
+    get_metastable_chars,
     Z_to_elem,
     elem_to_Z,
     build_id,
     build_nuclide_string,
-    parse_id,
     parse_nuclide_str,
+    parse_id,
     parse_nuclide,
     add_dictionaries,
     sort_dictionary_alphabetically,
@@ -23,6 +24,13 @@ class TestFunctions(unittest.TestCase):
     """
     Unit tests for the utils.py functions.
     """
+
+    def test_get_metastable_chars(self) -> None:
+        """
+        Test fetching of list of metastable state characters.
+        """
+
+        self.assertEqual(get_metastable_chars(), ["m", "n", "p", "q", "r"])
 
     def test_Z_to_elem(self) -> None:
         """
@@ -42,7 +50,7 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(elem_to_Z("Ca"), 20)
         self.assertEqual(elem_to_Z("Fe"), 26)
 
-    def test_built_id(self) -> None:
+    def test_build_id(self) -> None:
         """
         Test the canonical id builder.
         """
@@ -51,6 +59,9 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(build_id(53, 118), 531180000)
         self.assertEqual(build_id(53, 118, "m"), 531180001)
         self.assertEqual(build_id(65, 156, "n"), 651560002)
+        self.assertEqual(build_id(49, 129, "p"), 491290003)
+        self.assertEqual(build_id(71, 177, "q"), 711770004)
+        self.assertEqual(build_id(71, 177, "r"), 711770005)
 
         with self.assertRaises(ValueError):
             build_id(65, 156, "z")
@@ -64,19 +75,12 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(build_nuclide_string(53, 118), "I-118")
         self.assertEqual(build_nuclide_string(53, 118, "m"), "I-118m")
         self.assertEqual(build_nuclide_string(65, 156, "n"), "Tb-156n")
+        self.assertEqual(build_nuclide_string(49, 129, "p"), "In-129p")
+        self.assertEqual(build_nuclide_string(71, 177, "q"), "Lu-177q")
+        self.assertEqual(build_nuclide_string(71, 177, "r"), "Lu-177r")
 
         with self.assertRaises(ValueError):
             build_nuclide_string(999, 1000, "z")
-
-    def test_parse_id(self) -> None:
-        """
-        Test the canonical id to nuclide string converter.
-        """
-
-        self.assertEqual(parse_id(260560000), "Fe-56")
-        self.assertEqual(parse_id(531180000), "I-118")
-        self.assertEqual(parse_id(531180001), "I-118m")
-        self.assertEqual(parse_id(651560002), "Tb-156n")
 
     def test_parse_nuclide_str(self) -> None:
         """
@@ -105,6 +109,22 @@ class TestFunctions(unittest.TestCase):
         # Note following test won't work as need to metastable char to be lower case for it to be
         # identified as a metastable char not an element char:
         # self.assertEqual(parse_nuclide_str("192NiR"), "Ir-192n")
+        self.assertEqual(parse_nuclide_str("iN129P"), "In-129p")
+        self.assertEqual(parse_nuclide_str("177qLu"), "Lu-177q")
+        self.assertEqual(parse_nuclide_str("LU177R"), "Lu-177r")
+
+    def test_parse_id(self) -> None:
+        """
+        Test the canonical id to nuclide string converter.
+        """
+
+        self.assertEqual(parse_id(260560000), "Fe-56")
+        self.assertEqual(parse_id(531180000), "I-118")
+        self.assertEqual(parse_id(531180001), "I-118m")
+        self.assertEqual(parse_id(651560002), "Tb-156n")
+        self.assertEqual(parse_id(491290003), "In-129p")
+        self.assertEqual(parse_id(711770004), "Lu-177q")
+        self.assertEqual(parse_id(711770005), "Lu-177r")
 
     def test_parse_nuclide(self) -> None:
         """
@@ -123,6 +143,9 @@ class TestFunctions(unittest.TestCase):
                 "I-118m",
                 "Tb-156m",
                 "Tb-156n",
+                "In-129p",
+                "Lu-177q",
+                "Lu-177r",
             ]
         )
         dataset_name = "test"
@@ -168,6 +191,18 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(parse_nuclide("Tb156n", nuclides, dataset_name), "Tb-156n")
         self.assertEqual(parse_nuclide("156nTb", nuclides, dataset_name), "Tb-156n")
         self.assertEqual(parse_nuclide(651560002, nuclides, dataset_name), "Tb-156n")
+        self.assertEqual(parse_nuclide("In-129p", nuclides, dataset_name), "In-129p")
+        self.assertEqual(parse_nuclide("In129p", nuclides, dataset_name), "In-129p")
+        self.assertEqual(parse_nuclide("129pIn", nuclides, dataset_name), "In-129p")
+        self.assertEqual(parse_nuclide(491290003, nuclides, dataset_name), "In-129p")
+        self.assertEqual(parse_nuclide("Lu-177q", nuclides, dataset_name), "Lu-177q")
+        self.assertEqual(parse_nuclide("Lu177q", nuclides, dataset_name), "Lu-177q")
+        self.assertEqual(parse_nuclide("177qLu", nuclides, dataset_name), "Lu-177q")
+        self.assertEqual(parse_nuclide(711770004, nuclides, dataset_name), "Lu-177q")
+        self.assertEqual(parse_nuclide("Lu-177r", nuclides, dataset_name), "Lu-177r")
+        self.assertEqual(parse_nuclide("Lu-177r", nuclides, dataset_name), "Lu-177r")
+        self.assertEqual(parse_nuclide("177rLu", nuclides, dataset_name), "Lu-177r")
+        self.assertEqual(parse_nuclide(711770005, nuclides, dataset_name), "Lu-177r")
 
         # Catch erroneous strings
         with self.assertRaises(TypeError):


### PR DESCRIPTION
<!-- Thank you for contributing a Pull Request! Please ensure you also check the contributor guidelines:
https://github.com/radioactivedecay/radioactivedecay/blob/main/CONTRIBUTING.md -->

#### What does this PR implement/fix?
The code previously only supported metastable nuclear isomers with up to two states (i.e. Ir-192m, Ir-192n). This was fine for the ICRP-07 dataset which does not contain any higher metastable states. However, to future proof the code for new datasets, this PR adds support for up to the 6th metastable state, e.g. Lu-174m, Lu-174n, Lu-174p, Lu-174q, Lu-174r & Lu-174x.

#### Fixes Issue
<!-- Example: #62 or N/A -->
N/A


#### Other comments?
Note the character "o" is skipped when identifying metastable states. It goes "m", "n", "p", "q", "r", "x" for the first to sixth metastable state. See NUBASE2020 paper (F.G. Kondev et al 2021 Chinese Phys. C 45 030001) for more details.