### PR TITLE
Improve nuclide string parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
-## [0.X.XX] - 20XX-XX-XX
+## [0.4.13] - 2022-05-XX
 - Code improvement to support metastable states up to 6th state (#76).
 - Added labels for more decay modes (including heavy cluster decay modes) to decay chain plots code
 (#77).
+- Improve parsing of nuclide strings (#78). Note: you must use the correct capitalization of the
+metastable state and the element chars when using mass number first format, e.g. use '130nI' to get
+I-130n, not '130ni', '130Ni' or '130NI' as these will be mistaken as Nickel (Ni). Capitalization
+does not matter if using element first formats, e.g. 'I-130N' or 'I130N' will be correctly parsed
+to I-130n.
 
 ## [0.4.12] - 2022-3-24
 - Added more stable products to the default ICRP-107 dataset (#75).

--- a/radioactivedecay/converters.py
+++ b/radioactivedecay/converters.py
@@ -36,6 +36,14 @@ class UnitConverter(ABC):
         Dictionary containing amounts of each mole unit per mol.
     year_units : set
         Set containing all year units. Used to pick up where days in year conversion is needed.
+    time_unit_err_msg : str
+        Error message for time unit ValueError.
+    activity_unit_err_msg : str
+        Error message for activity unit ValueError.
+    mass_unit_err_msg : str
+        Error message for mass unit ValueError.
+    moles_unit_err_msg : str
+        Error message for moles unit ValueError.
 
     """
 
@@ -44,6 +52,11 @@ class UnitConverter(ABC):
     mass_units: Dict[str, Union[float, Expr]]
     moles_units: Dict[str, Union[float, Expr]]
     year_units = {"y", "yr", "year", "years", "ky", "My", "By", "Gy", "Ty", "Py"}
+
+    time_unit_err_msg = 'is not a valid time unit, e.g. "s", "m", "h", "d" or "y".'
+    activity_unit_err_msg = 'is not a valid activitiy unit, e.g. "Bq", "kBq", "Ci"...'
+    mass_unit_err_msg = 'is not a valid mass unit, e.g. "g", "kg", "mg"...'
+    moles_unit_err_msg = 'is not a valid moles unit, e.g. "mol", "kmol", "mmol"...'
 
     @classmethod
     def time_unit_conv(
@@ -80,13 +93,9 @@ class UnitConverter(ABC):
         """
 
         if units_from not in cls.time_units:
-            raise ValueError(
-                f'{units_from} is not a valid unit, e.g. "s", "m", "h", "d" or "y".'
-            )
+            raise ValueError(f"{units_from} {cls.time_unit_err_msg}")
         if units_to not in cls.time_units:
-            raise ValueError(
-                f'{units_to} is not a valid unit, e.g. "s", "m", "h", "d" or "y".'
-            )
+            raise ValueError(f"{units_to} {cls.time_unit_err_msg}")
 
         factor_from = cls.time_units[units_from]
         factor_to = cls.time_units[units_to]
@@ -125,13 +134,9 @@ class UnitConverter(ABC):
         """
 
         if units_from not in cls.activity_units:
-            raise ValueError(
-                f'{units_from} is not a valid activitiy unit, e.g. "Bq", "kBq", "Ci"...'
-            )
+            raise ValueError(f"{units_from} {cls.activity_unit_err_msg}")
         if units_to not in cls.activity_units:
-            raise ValueError(
-                f'{units_to} is not a valid activitiy unit, e.g. "Bq", "kBq", "Ci"...'
-            )
+            raise ValueError(f"{units_to} {cls.activity_unit_err_msg}")
 
         return activity * cls.activity_units[units_from] / cls.activity_units[units_to]
 
@@ -164,13 +169,9 @@ class UnitConverter(ABC):
         """
 
         if units_from not in cls.mass_units:
-            raise ValueError(
-                f'{units_from} is not a valid mass unit, e.g. "g", "kg", "mg"...'
-            )
+            raise ValueError(f"{units_from} {cls.mass_unit_err_msg}")
         if units_to not in cls.mass_units:
-            raise ValueError(
-                f'{units_to} is not a valid mass unit, e.g. "g", "kg", "mg"...'
-            )
+            raise ValueError(f"{units_to} {cls.mass_unit_err_msg}")
 
         return mass * cls.mass_units[units_from] / cls.mass_units[units_to]
 
@@ -203,13 +204,9 @@ class UnitConverter(ABC):
         """
 
         if units_from not in cls.moles_units:
-            raise ValueError(
-                f'{units_from} is not a valid unit, e.g. "mol", "kmol", "mmol"...'
-            )
+            raise ValueError(f"{units_from} {cls.moles_unit_err_msg}")
         if units_to not in cls.moles_units:
-            raise ValueError(
-                f'{units_to} is not a valid unit, e.g. "mol", "kmol", "mmol"...'
-            )
+            raise ValueError(f"{units_to} {cls.moles_unit_err_msg}")
 
         return moles * cls.moles_units[units_from] / cls.moles_units[units_to]
 

--- a/radioactivedecay/converters.py
+++ b/radioactivedecay/converters.py
@@ -81,12 +81,11 @@ class UnitConverter(ABC):
 
         if units_from not in cls.time_units:
             raise ValueError(
-                str(units_from)
-                + ' is not a valid unit, e.g. "s", "m", "h", "d" or "y".'
+                f'{units_from} is not a valid unit, e.g. "s", "m", "h", "d" or "y".'
             )
         if units_to not in cls.time_units:
             raise ValueError(
-                str(units_to) + ' is not a valid unit, e.g. "s", "m", "h", "d" or "y".'
+                f'{units_to} is not a valid unit, e.g. "s", "m", "h", "d" or "y".'
             )
 
         factor_from = cls.time_units[units_from]
@@ -127,12 +126,11 @@ class UnitConverter(ABC):
 
         if units_from not in cls.activity_units:
             raise ValueError(
-                str(units_from)
-                + ' is not a valid activitiy unit, e.g. "Bq", "kBq", "Ci"...'
+                f'{units_from} is not a valid activitiy unit, e.g. "Bq", "kBq", "Ci"...'
             )
         if units_to not in cls.activity_units:
             raise ValueError(
-                str(units_to) + ' is not a activitiy unit, e.g. "Bq", "kBq", "Ci"...'
+                f'{units_to} is not a valid activitiy unit, e.g. "Bq", "kBq", "Ci"...'
             )
 
         return activity * cls.activity_units[units_from] / cls.activity_units[units_to]
@@ -167,11 +165,11 @@ class UnitConverter(ABC):
 
         if units_from not in cls.mass_units:
             raise ValueError(
-                str(units_from) + ' is not a valid mass unit, e.g. "g", "kg", "mg"...'
+                f'{units_from} is not a valid mass unit, e.g. "g", "kg", "mg"...'
             )
         if units_to not in cls.mass_units:
             raise ValueError(
-                str(units_to) + ' is not a valid mass unit, e.g. "g", "kg", "mg"...'
+                f'{units_to} is not a valid mass unit, e.g. "g", "kg", "mg"...'
             )
 
         return mass * cls.mass_units[units_from] / cls.mass_units[units_to]
@@ -206,11 +204,11 @@ class UnitConverter(ABC):
 
         if units_from not in cls.moles_units:
             raise ValueError(
-                str(units_from) + ' is not a valid unit, e.g. "mol", "kmol", "mmol"...'
+                f'{units_from} is not a valid unit, e.g. "mol", "kmol", "mmol"...'
             )
         if units_to not in cls.moles_units:
             raise ValueError(
-                str(units_to) + ' is not a valid unit, e.g. "mol", "kmol", "mmol"...'
+                f'{units_to} is not a valid unit, e.g. "mol", "kmol", "mmol"...'
             )
 
         return moles * cls.moles_units[units_from] / cls.moles_units[units_to]

--- a/radioactivedecay/decaydata.py
+++ b/radioactivedecay/decaydata.py
@@ -434,6 +434,12 @@ class DecayData:
         """
         Property to return DecayMatricesSympy instance if it exists, or raise an error if the
         dataset does not contain SymPy data.
+
+        Raises
+        ------
+        ValueError
+            If the DecayData instance does not contain any SymPy decay data.
+
         """
 
         if self._sympy_data is None:
@@ -445,6 +451,12 @@ class DecayData:
         """
         Property to return SymPy number of days in one year if it exists, or raise an error if the
         dataset does not contain SymPy data.
+
+        Raises
+        ------
+        ValueError
+            If the DecayData instance does not contain any SymPy decay data.
+
         """
 
         if self._sympy_year_conv is None:

--- a/radioactivedecay/inventory.py
+++ b/radioactivedecay/inventory.py
@@ -239,7 +239,7 @@ class AbstractInventory(ABC):
                 for nuc, mass in contents.items()
             }
         else:
-            raise ValueError(units + " is not a supported unit.")
+            raise ValueError(f"{units} is not a supported unit.")
 
         return contents_as_numbers
 
@@ -485,10 +485,8 @@ class AbstractInventory(ABC):
 
         if self.decay_data != other.decay_data:
             raise ValueError(
-                "Decay datasets do not match. "
-                + self.decay_data.dataset_name
-                + " and "
-                + other.decay_data.dataset_name
+                f"Decay datasets do not match. {self.decay_data.dataset_name} and "
+                f"{other.decay_data.dataset_name}"
             )
         new_contents = add_dictionaries(self.contents, other.contents)
         return self.__class__(new_contents, "num", False, self.decay_data)
@@ -498,10 +496,8 @@ class AbstractInventory(ABC):
 
         if self.decay_data != other.decay_data:
             raise ValueError(
-                "Decay datasets do not match. "
-                + self.decay_data.dataset_name
-                + " and "
-                + other.decay_data.dataset_name
+                f"Decay datasets do not match. {self.decay_data.dataset_name} and "
+                f"{other.decay_data.dataset_name}"
             )
         sub_contents = other.contents.copy()
         sub_contents.update(
@@ -564,7 +560,7 @@ class AbstractInventory(ABC):
         """
         raise NotImplementedError(
             "Method takes a nuclide string, a canonical id, a Nuclide instance, or list of nuclide"
-            + " strings, canonical ids or Nuclide instances as a parameter."
+            " strings, canonical ids or Nuclide instances as a parameter."
         )
 
     @remove.register(str)
@@ -578,7 +574,7 @@ class AbstractInventory(ABC):
         )
         new_contents = self.contents.copy()
         if delete not in new_contents:
-            raise ValueError(delete + " does not exist in this inventory.")
+            raise ValueError(f"{delete} does not exist in this inventory.")
         new_contents.pop(delete)
 
         self.contents = new_contents
@@ -594,7 +590,7 @@ class AbstractInventory(ABC):
         )
         new_contents = self.contents.copy()
         if delete_str not in new_contents:
-            raise ValueError(delete_str + " does not exist in this inventory.")
+            raise ValueError(f"{delete_str} does not exist in this inventory.")
         new_contents.pop(delete_str)
 
         self.contents = new_contents
@@ -610,7 +606,7 @@ class AbstractInventory(ABC):
         )
         new_contents = self.contents.copy()
         if delete_str not in new_contents:
-            raise ValueError(delete_str + " does not exist in this inventory.")
+            raise ValueError(f"{delete_str} does not exist in this inventory.")
         new_contents.pop(delete_str)
 
         self.contents = new_contents
@@ -634,7 +630,7 @@ class AbstractInventory(ABC):
         new_contents = self.contents.copy()
         for nuc in delete_list:
             if nuc not in new_contents:
-                raise ValueError(nuc + " does not exist in this inventory.")
+                raise ValueError(f"{nuc} does not exist in this inventory.")
             new_contents.pop(nuc)
 
         self.contents = new_contents
@@ -897,7 +893,7 @@ class AbstractInventory(ABC):
                 display = self.decay(0).nuclides
             else:
                 raise ValueError(
-                    str(order) + " is not a valid string for the order parameter."
+                    f"{order} is not a valid string for the order parameter."
                 )
         else:
             if isinstance(display, str):
@@ -1156,7 +1152,7 @@ class Inventory(AbstractInventory):
     def __repr__(self) -> str:
         return (
             f"Inventory activities (Bq): {self.activities()}, "
-            + f"decay dataset: {self.decay_data.dataset_name}"
+            f"decay dataset: {self.decay_data.dataset_name}"
         )
 
 
@@ -1591,5 +1587,5 @@ class InventoryHP(AbstractInventory):
     def __repr__(self) -> str:
         return (
             f"InventoryHP activities (Bq): {self.activities()}, "
-            + f"decay dataset: {self.decay_data.dataset_name}"
+            f"decay dataset: {self.decay_data.dataset_name}"
         )

--- a/radioactivedecay/nuclide.py
+++ b/radioactivedecay/nuclide.py
@@ -382,12 +382,7 @@ class Nuclide:
         return fig, axes
 
     def __repr__(self) -> str:
-        rep = (
-            "Nuclide: "
-            + self.nuclide
-            + ", decay dataset: "
-            + self.decay_data.dataset_name
-        )
+        rep = f"Nuclide: {self.nuclide}, decay dataset: {self.decay_data.dataset_name}"
 
         return rep
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -42,6 +42,23 @@ class TestUnitConverterFloat(unittest.TestCase):
         self.assertEqual(UnitConverterFloat.mass_units["g"], 1.0)
         self.assertEqual(UnitConverterFloat.moles_units["mol"], 1.0)
 
+        self.assertEqual(
+            UnitConverterFloat.time_unit_err_msg,
+            'is not a valid time unit, e.g. "s", "m", "h", "d" or "y".',
+        )
+        self.assertEqual(
+            UnitConverterFloat.activity_unit_err_msg,
+            'is not a valid activitiy unit, e.g. "Bq", "kBq", "Ci"...',
+        )
+        self.assertEqual(
+            UnitConverterFloat.mass_unit_err_msg,
+            'is not a valid mass unit, e.g. "g", "kg", "mg"...',
+        )
+        self.assertEqual(
+            UnitConverterFloat.moles_unit_err_msg,
+            'is not a valid moles unit, e.g. "mol", "kmol", "mmol"...',
+        )
+
     def test_time_unit_conv_seconds(self) -> None:
         """
         Test conversion between seconds and different time units.


### PR DESCRIPTION
#### What does this PR implement/fix?
@lemointm & the TARDIS project found that some capitalizations of nuclide strings were being parsed incorrectly. Previously
```python3
rd.utils.parse_nuclide_str("ni56")
'I-56n'
```

This PR refactors the parse_nuclide_str() function to give more robust and predictable parsing of nuclide strings.

- Now all element first specifications (e.g. "ni56", "Ni-56", or "NI69M") should parse correctly, irrespective of capitalization of the element symbol or the metastable state character.
- For mass number first specifications (e.g. "192nIr", "99mTc"), capitalization won't matter if the element symbol is two characters.
- If the element symbol is one character, you need to use the correct capitalization (i.e. "91my or "91My") will not parse correctly to give Y-91m. This is related to ambiguity issues (e.g. is "123ni" a Nickel ground state or a metastable state of Iodine?). Fixing the ambiguity issues would require considering the mass number and nuclear data. It is too much effort, please use correct capitalization instead, or use a element symbol first specification (e.g. "I-123n").

#### Fixes Issue
N/A


#### Other comments?
- Also includes some refactoring to f-strings and better docstring entries for exceptions.