### PR TITLE
Fix unit tests for normal precision decay methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.4.15] - 2022-09-08
+- Fix normal precision inventory unit tests for `decay()` and `cumulative_decays()` methods (#84).
+The tests now warn if the calculated floats are not exact matches for the test defaults, and assert
+that the calculated floats are within max(rel_tol=1e-7, abs_tol=1e-30) of the expected values. This
+means the tests that had previously started flaking on GitHub Actions CI (sporadically) will now
+pass.
+
 ## [0.4.14] - 2022-09-06
 - Fix bug where high-precision (SymPy) default dataset had incorrect half-lives for Th-232, Sm-147
 and Rb-87 (#82). All users performing `InventoryHP` decay calculations for chains containing these

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ automatically harvested by Sphinx to create the API section of the
 
 These notes describe the steps for cutting a new release:
 
-* Update the version number in radioactivedecay/__init__.py
+* Update the version number in `radioactivedecay/__init__.py`
 * Make sure
 [CHANGELOG.md](https://github.com/radioactivedecay/radioactivedecay/blob/main/CHANGELOG.md)
 documents the changes

--- a/radioactivedecay/__init__.py
+++ b/radioactivedecay/__init__.py
@@ -25,7 +25,7 @@ imported as ``rd``:
 
 """
 
-__version__ = "0.4.14"
+__version__ = "0.4.15"
 
 from radioactivedecay.decaydata import DecayData, DEFAULTDATA
 from radioactivedecay.inventory import Inventory, InventoryHP

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -19,7 +19,9 @@ from radioactivedecay.nuclide import Nuclide
 # pylint: disable=protected-access, too-many-public-methods
 
 
-def warning_message_if_dict_not_equal(calculated: Dict[str, float], expected: Dict[str, float]) -> None:
+def warning_message_if_dict_not_equal(
+    calculated: Dict[str, float], expected: Dict[str, float]
+) -> None:
     """
     Warning message if calculated dictionary of floats is not equal to expected dictionary of floats.
     """

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -3,6 +3,8 @@ Unit tests for inventory.py classes and methods.
 """
 
 import copy
+import math
+from typing import Dict
 import unittest
 from unittest.mock import patch
 from sympy import Integer, log
@@ -14,6 +16,28 @@ from radioactivedecay.inventory import (
 from radioactivedecay.nuclide import Nuclide
 
 # pylint: disable=protected-access, too-many-public-methods
+
+
+def dict_assert_almost_equal(
+    test_case: unittest.TestCase,
+    dict_a: Dict[str, float],
+    dict_b: Dict[str, float],
+) -> None:
+    """
+    Check whether two dictionaries with str keys and float values have:
+        i) the same keys
+        ii) float values are close (using `math.isclose()`)
+
+    This function could be improved by outputting a better traceback in the event that an
+    assertTrue fails.
+    """
+
+    test_case.assertEqual(set(dict_a), set(dict_b))
+
+    for key in dict_a:
+        test_case.assertTrue(
+            math.isclose(dict_a[key], dict_b[key], rel_tol=1e-13, abs_tol=1e-30)
+        )
 
 
 class TestInventory(unittest.TestCase):
@@ -393,7 +417,8 @@ class TestInventory(unittest.TestCase):
         inv = Inventory({"H-3": 10.0}, "Bq")
         self.assertEqual(inv.decay(12.32, "y").activities(), {"H-3": 5.0, "He-3": 0.0})
         inv = Inventory({"Tc-99m": 2.3, "I-123": 5.8}, "Bq")
-        self.assertEqual(
+        dict_assert_almost_equal(
+            self,
             inv.decay(20.0, "h").activities(),
             {
                 "I-123": 2.040459244534774,
@@ -406,7 +431,8 @@ class TestInventory(unittest.TestCase):
             },
         )
         inv = Inventory({"U-238": 99.274, "U-235": 0.720, "U-234": 0.005}, "Bq")
-        self.assertEqual(
+        dict_assert_almost_equal(
+            self,
             inv.decay(1e9, "y").activities(),
             {
                 "Ac-227": 0.2690006281740556,
@@ -464,7 +490,8 @@ class TestInventory(unittest.TestCase):
         )
 
         inv = Inventory({"Tc-99m": 2.3, "I-123": 5.8}, "num")
-        self.assertEqual(
+        dict_assert_almost_equal(
+            self,
             inv.cumulative_decays(20.0, "h"),
             {
                 "I-123": 3.759540755465226,
@@ -476,7 +503,8 @@ class TestInventory(unittest.TestCase):
         )
 
         inv = Inventory({"U-238": 99.274, "U-235": 0.720, "U-234": 0.005}, "num")
-        self.assertEqual(
+        dict_assert_almost_equal(
+            self,
             inv.cumulative_decays(1e9, "y"),
             {
                 "Ac-227": 0.45099937182594435,

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -37,7 +37,7 @@ def dict_assert_almost_equal(
     for key in dict_a:
         try:
             test_case.assertTrue(
-                math.isclose(dict_a[key], dict_b[key], rel_tol=1e-13, abs_tol=1e-30)
+                math.isclose(dict_a[key], dict_b[key], rel_tol=1e-7, abs_tol=1e-30)
             )
         except AssertionError as error:
             raise AssertionError(

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -35,9 +35,14 @@ def dict_assert_almost_equal(
     test_case.assertEqual(set(dict_a), set(dict_b))
 
     for key in dict_a:
-        test_case.assertTrue(
-            math.isclose(dict_a[key], dict_b[key], rel_tol=1e-13, abs_tol=1e-30)
-        )
+        try:
+            test_case.assertTrue(
+                math.isclose(dict_a[key], dict_b[key], rel_tol=1e-13, abs_tol=1e-30)
+            )
+        except AssertionError as error:
+            raise AssertionError(
+                f"Floats are not within error tolerance: {dict_a[key]} {dict_b[key]} for nuclide {key}."
+            ) from error
 
 
 class TestInventory(unittest.TestCase):


### PR DESCRIPTION
#### What does this PR implement/fix?
Previously around when v0.4.14 was released, normal precision `decay()` and `cumulative_decays()` unit tests started failing on GitHub Actions and conda-forge feedstock CI. I couldn't reproduce these failures locally (tried Windows, MacOS, Ubuntu and using the CI Docker images locally), but the cause is possibly floating point error build up. The tests fail on some CI runs, but not others (sporadic failures).

The modifications for release 0.4.14 were independent of the failures, so I guess the origin is changes in NumPy/SciPy, their underlying libraries or with the CI settings somewhere.

This commit introduces a new `dict_assert_almost_equal()` function within the tests, which uses `math.isclose()` to check if two floats are almost equal. Found rel_tol=1e-7, abs_tol=1e-30 were reasonably tight tolerance settings for the allowed float difference.

The tests will also warn if the floats are not exactly equal. This means we can see if the tests would have passed or not under the previous stricter testing regime.

#### Fixes Issue
N/A


#### Other comments?
~~One for the future: `dict_assert_almost_equal()` could do with showing a better traceback if an assertion fails, i.e. it should show the two floats and the nuclide key that caused the failure.~~ **Added**