### PR TITLE
Run tests Github Action workflow every Mon at 1200 UTC

### DIFF
--- a/.github/workflows/1_tests.yml
+++ b/.github/workflows/1_tests.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron: "0 12 * * 1"  # every Monday at 12:00 UTC
   workflow_dispatch:
 
 jobs:

--- a/radioactivedecay/decaydata.py
+++ b/radioactivedecay/decaydata.py
@@ -252,7 +252,6 @@ class DecayMatricesScipy(DecayMatrices):
         )
 
     def __repr__(self) -> str:
-
         return (
             "DecayMatricesScipy: data stored in SciPy/NumPy objects for double precision "
             "calculations."
@@ -337,7 +336,6 @@ class DecayMatricesSympy(DecayMatrices):
         )
 
     def __repr__(self) -> str:
-
         return (
             "DecayMatricesSympy: data stored in SymPy objects for arbitrary-precision "
             "calculations."
@@ -415,7 +413,6 @@ class DecayData:
         sympy_data: Optional[DecayMatricesSympy] = None,
         sympy_year_conv: Optional[Expr] = None,
     ) -> None:
-
         self.dataset_name = dataset_name
         self.bfs = bfs
         self.float_year_conv = float_year_conv

--- a/radioactivedecay/inventory.py
+++ b/radioactivedecay/inventory.py
@@ -113,7 +113,6 @@ class AbstractInventory(ABC):
         check: bool = True,
         decay_data: DecayData = DEFAULTDATA,
     ) -> None:
-
         self.decay_data = decay_data
         self.decay_matrices = self._get_decay_matrices()
 
@@ -1216,7 +1215,6 @@ class InventoryHP(AbstractInventory):
         check: bool = True,
         decay_data: DecayData = DEFAULTDATA,
     ) -> None:
-
         if check is True:
             try:
                 assert decay_data.sympy_data


### PR DESCRIPTION
<!-- Thank you for contributing a Pull Request! Please ensure you also check the contributor guidelines:
https://github.com/radioactivedecay/radioactivedecay/blob/main/CONTRIBUTING.md -->

#### What does this PR implement/fix?

It makes sense to run the tests GitHub Action on a regular schedule. This will catch early if new versions of dependencies cause problems with this package (e.g. SymPy updates breaking compatibility with existing SymPy decay matrix pickle files)...

#### Fixes Issue
N/A


#### Other comments?
