### PR TITLE
Fix dpm bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.17] - 2023-03-10
+- Fix bug where the conversion of dpm to other activity units, and vice versa, was incorrect (#87 &
+#88).
+
 ## [0.4.16] - 2022-10-29
 - Added support for Python v3.11. Use latest importlib-resources API (`files()` etc.) to fix
 warnings. Fix pylint `__repr__()` usage warnings in tests. Use isort to sort imports and check in

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -246,6 +246,7 @@ Special thanks to:
 * `Jonathan Wing <https://github.com/JWingUtk>`_
 * `radioactivedecay-github <https://github.com/radioactivedecay-github>`_
 * `Christian Schreinemachers <https://github.com/Cs137>`_
+* `Sean Neutzmann <https://github.com/snuetzmann>`_
 
 for suggestions, support and assistance to this project.
 

--- a/radioactivedecay/__init__.py
+++ b/radioactivedecay/__init__.py
@@ -25,7 +25,7 @@ imported as ``rd``:
 
 """
 
-__version__ = "0.4.16"
+__version__ = "0.4.17"
 
 from radioactivedecay.decaydata import DEFAULTDATA, DecayData
 from radioactivedecay.inventory import Inventory, InventoryHP

--- a/radioactivedecay/converters.py
+++ b/radioactivedecay/converters.py
@@ -272,7 +272,7 @@ class UnitConverterFloat(UnitConverter):
         "TCi": 1.0e12 * 3.7e10,
         "PCi": 1.0e15 * 3.7e10,
         "ECi": 1.0e18 * 3.7e10,
-        "dpm": 60.0,
+        "dpm": 1.0 / 60.0,
     }
 
     mass_units: Dict[str, float] = {
@@ -364,7 +364,7 @@ class UnitConverterSympy(UnitConverter):
         "TCi": Integer(1000000000000) * 37000000000,
         "PCi": Integer(1000000000000000) * 37000000000,
         "ECi": Integer(1000000000000000000) * 37000000000,
-        "dpm": Integer(60),
+        "dpm": Integer(1) / 60,
     }
 
     mass_units: Dict[str, Expr] = {

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -387,9 +387,7 @@ class TestUnitConverterFloat(unittest.TestCase):
             places=(18 + 15),
         )
 
-        self.assertEqual(
-            UnitConverterFloat.activity_unit_conv(1.0, "Bq", "dpm"), 1.0 / 60.0
-        )
+        self.assertEqual(UnitConverterFloat.activity_unit_conv(1.0, "Bq", "dpm"), 60.0)
 
         # Catch some incorrect activity units
         with self.assertRaises(ValueError):
@@ -740,7 +738,7 @@ class TestUnitConverterSympy(unittest.TestCase):
 
         self.assertEqual(
             UnitConverterSympy.activity_unit_conv(Integer(1), "Bq", "dpm"),
-            1 / Integer(60),
+            Integer(60),
         )
 
         # Catch some incorrect activity units

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -22,7 +22,8 @@ def warning_message_if_dict_not_equal(
     calculated: Dict[str, float], expected: Dict[str, float]
 ) -> None:
     """
-    Warning message if calculated dictionary of floats is not equal to expected dictionary of floats.
+    Warning message if calculated dictionary of floats is not equal to expected dictionary of
+    floats.
     """
 
     return (


### PR DESCRIPTION
<!-- Thank you for contributing a Pull Request! Please ensure you also check the contributor guidelines:
https://github.com/radioactivedecay/radioactivedecay/blob/main/CONTRIBUTING.md -->

#### What does this PR implement/fix?
The conversion between dpm and other activity units was incorrect: it divided by 60 when converting Bq -> dpm rather than timesing by 60.

This PR corrects the mistake, corrects the tests which were also wrong, and releases v0.4.17 so users have the fix available straight away.

#### Fixes Issue
#87 


#### Other comments?
Thanks to @snuetzmann for the bug report.
