### PR TITLE
Release v0.4.18: prohibit supplying activity of stable nuclide when instantiating an inventory

### DIFF
--- a/.github/workflows/1_tests.yml
+++ b/.github/workflows/1_tests.yml
@@ -18,9 +18,9 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         include:
           - os: windows-latest
-            python-version: '3.7'
-          - os: macos-latest
-            python-version: '3.7'
+            python-version: '3.11'
+          #- os: macos-latest
+          #  python-version: '3.7'
     timeout-minutes: 10
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.18] - 2023-06-27
+-  Prohibit instantiation of an inventory if the user supplies an activity for a stable nuclide
+(#92).
+
 ## [0.4.17] - 2023-03-10
 - Fix bug where the conversion of dpm to other activity units, and vice versa, was incorrect (#87 &
 #88).

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -244,9 +244,10 @@ Special thanks to:
 * `Hunter Ratliff <https://hratliff.com/>`_
 * `Jayson Vavrek <https://github.com/jvavrek>`_
 * `Jonathan Wing <https://github.com/JWingUtk>`_
-* `radioactivedecay-github <https://github.com/radioactivedecay-github>`_
+* `@radioactivedecay-github <https://github.com/radioactivedecay-github>`_
 * `Christian Schreinemachers <https://github.com/Cs137>`_
 * `Sean Neutzmann <https://github.com/snuetzmann>`_
+* `@buresjan <https://github.com/buresjan>`_
 
 for suggestions, support and assistance to this project.
 

--- a/radioactivedecay/__init__.py
+++ b/radioactivedecay/__init__.py
@@ -25,7 +25,7 @@ imported as ``rd``:
 
 """
 
-__version__ = "0.4.17"
+__version__ = "0.4.18"
 
 from radioactivedecay.decaydata import DEFAULTDATA, DecayData
 from radioactivedecay.inventory import Inventory, InventoryHP

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -81,7 +81,7 @@ class TestInventory(unittest.TestCase):
         inv = Inventory({tritium: 1.0}, "num", True)
         self.assertEqual(inv.contents, {"H-3": 1})
 
-        # check that check=False turns off nuclide string convertion and quantity check
+        # check that check=False turns off nuclide string conversion and quantity check
         inv = Inventory({"H3": 1.0}, "num", False)
         self.assertEqual(inv.contents, {"H3": 1.0})
         inv = Inventory({"H-3": -1.0}, "num", False)
@@ -91,9 +91,13 @@ class TestInventory(unittest.TestCase):
         inv = Inventory({"He-3": 2.0, "H-3": 1.0}, "num", False)
         self.assertEqual(inv.contents, {"H-3": 1.0, "He-3": 2.0})
 
-        # check converion of input quantity to number
+        # check conversion of input quantity to number
         inv = Inventory({"H-3": 1.0}, "mBq")
         self.assertEqual(inv.contents, {"H-3": 560892.8957794083})
+
+        # check instantiation with a stable nuclide activity raises a ValueError
+        with self.assertRaises(ValueError):
+            Inventory({"He-3": 0.0}, "Bq", False)
 
     def test__parse_nuclides(self) -> None:
         """
@@ -141,29 +145,29 @@ class TestInventory(unittest.TestCase):
 
         inv = Inventory({"H3": 1}, "num", True)
         self.assertEqual(
-            inv._convert_to_number({"H-3": 1.0}, "num"),
+            inv._convert_to_number({"H-3": 1.0}, "num", "dataset_name"),
             {"H-3": 1.0},
         )
         self.assertEqual(
-            inv._convert_to_number({"H-3": 1.0}, "Bq"),
+            inv._convert_to_number({"H-3": 1.0}, "Bq", "dataset_name"),
             {"H-3": 560892895.7794082},
         )
         self.assertEqual(
-            inv._convert_to_number({"H-3": 1.0}, "mBq"),
+            inv._convert_to_number({"H-3": 1.0}, "mBq", "dataset_name"),
             {"H-3": 560892.8957794083},
         )
         self.assertEqual(
-            inv._convert_to_number({"H-3": 1.0}, "mol"),
+            inv._convert_to_number({"H-3": 1.0}, "mol", "dataset_name"),
             {"H-3": 6.02214076e23},
         )
         self.assertEqual(
-            inv._convert_to_number({"He-3": 1.0}, "kg"),
+            inv._convert_to_number({"He-3": 1.0}, "kg", "dataset_name"),
             {"He-3": 1.9967116089131648e26},
         )
 
         # check catch of incorrect units
         with self.assertRaises(ValueError):
-            inv._convert_to_number({"H-3": 1.0}, "xyz")
+            inv._convert_to_number({"H-3": 1.0}, "xyz", "dataset_name")
 
     def test_nuclides(self) -> None:
         """
@@ -728,6 +732,10 @@ class TestInventoryHP(unittest.TestCase):
         temp_data._sympy_data = None
         with self.assertRaises(ValueError):
             InventoryHP({"H3": 1}, "Bq", True, temp_data)
+
+        # check instantiation with a stable nuclide activity raises a ValueError
+        with self.assertRaises(ValueError):
+            InventoryHP({"He-3": 0.0}, "Bq", False)
 
     def test_numbers(self) -> None:
         """


### PR DESCRIPTION
<!-- Thank you for contributing a Pull Request! Please ensure you also check the contributor guidelines:
https://github.com/radioactivedecay/radioactivedecay/blob/main/CONTRIBUTING.md -->

#### What does this PR implement/fix?

In #92 @buresjan raised the issue of users supplying an activity for a stable nuclide when creating an inventory. This PR prohibits this by raising a ValueError.

Uses can still instantiate inventories using a mixture of units by adding together two inventories, e.g.:

```
>>> inv = rd.Inventory({"H-3": 1.0}, "TBq") + rd.Inventory({"He-3": 1.0}, "mmol")
>>> inv
Inventory activities (Bq): {'H-3': 1000000000000.0, 'He-3': 0.0}, decay dataset: icrp107_ame2020_nubase2020
>>> inv.moles()
{'H-3': 0.0009313845659419762, 'He-3': 0.001}
```


#### Fixes Issue
#92 


#### Other comments?
N/A
