### PR TITLE
Allow instantiation of Inventorys with numpy ints

### DIFF
--- a/.github/workflows/2_coverage.yml
+++ b/.github/workflows/2_coverage.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7']
+        python-version: ['3.11']
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/3_code_formatting.yml
+++ b/.github/workflows/3_code_formatting.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7']
+        python-version: ['3.11']
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/4_docs_build.yml
+++ b/.github/workflows/4_docs_build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7']
+        python-version: ['3.11']
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/5_docs_deploy.yml
+++ b/.github/workflows/5_docs_deploy.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7']
+        python-version: ['3.11']
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/6_pypi_release.yml
+++ b/.github/workflows/6_pypi_release.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7']
+        python-version: ['3.11']
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.19] - 2023-08-05
+-  Fix bug whereby inventories would not instantiate with NumPy int datatypes (e.g. `numpy.int32`)
+for the nuclide quantity in the instantiation dictionary. Previously a ValueError was raised (#96).
+
 ## [0.4.18] - 2023-06-27
 -  Prohibit instantiation of an inventory if the user supplies an activity for a stable nuclide
 (#92).

--- a/radioactivedecay/__init__.py
+++ b/radioactivedecay/__init__.py
@@ -25,7 +25,7 @@ imported as ``rd``:
 
 """
 
-__version__ = "0.4.18"
+__version__ = "0.4.19"
 
 from radioactivedecay.decaydata import DEFAULTDATA, DecayData
 from radioactivedecay.inventory import Inventory, InventoryHP

--- a/radioactivedecay/inventory.py
+++ b/radioactivedecay/inventory.py
@@ -16,6 +16,7 @@ as ``rd``:
 
 """
 
+import numbers
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
@@ -155,7 +156,7 @@ class AbstractInventory(ABC):
         """Checks that the nuclide quantities in contents (dictionary values) are valid."""
 
         for nuc, inp in contents.items():
-            if isinstance(inp, (float, int, Expr)):
+            if isinstance(inp, (numbers.Number, Expr)):
                 if inp >= 0:
                     continue
             raise ValueError(f"{inp} is not a valid quantity of nuclide {nuc}.")

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -9,6 +9,7 @@ import warnings
 from typing import Dict
 from unittest.mock import patch
 
+import numpy as np
 from sympy import Integer, log
 
 from radioactivedecay.decaydata import DEFAULTDATA, load_dataset
@@ -98,6 +99,10 @@ class TestInventory(unittest.TestCase):
         # check instantiation with a stable nuclide activity raises a ValueError
         with self.assertRaises(ValueError):
             Inventory({"He-3": 0.0}, "Bq", False)
+
+        # check instantiation with NumPy int datatype
+        inv = Inventory({"H-3": np.int32(1)}, "num")
+        self.assertEqual(inv.contents, {"H-3": 1})
 
     def test__parse_nuclides(self) -> None:
         """


### PR DESCRIPTION
<!-- Thank you for contributing a Pull Request! Please ensure you also check the contributor guidelines:
https://github.com/radioactivedecay/radioactivedecay/blob/main/CONTRIBUTING.md -->

#### What does this PR implement/fix?

Previously instantiating with inventories with NumPy int datatypes in the dictionary would cause ValueErrors. The bad isintance() check which caused is fixed to allow numpy int datatypes (`numpy.int32` etc.)


#### Fixes Issue
N/A


#### Other comments?
A little related to #95 so thanks for starting that discussion @buresjan