### PR TITLE
Release v0.4.20 - Adds `rd.read_csv()` function for creating an inventory from a CSV file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.20] - 2023-08-08
+- Add `rd.read_csv()` function for creating an inventory by reading nuclides & quantities (and
+optionally units) in from a CSV file (#94).
+
 ## [0.4.19] - 2023-08-05
 -  Fix bug whereby inventories would not instantiate with NumPy int datatypes (e.g. `numpy.int32`)
 for the nuclide quantity in the instantiation dictionary. Previously a ValueError was raised (#96).

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -9,6 +9,7 @@ API
    :caption: Modules:
    
    decaydata
+   fileio
    inventory
    nuclide
    utils

--- a/docs/source/fileio.rst
+++ b/docs/source/fileio.rst
@@ -1,0 +1,5 @@
+fileio
+======
+
+.. automodule:: radioactivedecay.fileio
+   :members:

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -65,6 +65,28 @@ to contain activities in Bq. The user can easily specify different units:
     >>> inv.numbers()
     {'U-234': 1500.0, 'U-235': 3000.0, 'U-238': 2000.0}
 
+It is also possible to create an inventory by reading directly from a CSV-type
+file via the ``rd.read_csv()`` function. The file's first column should contain
+the nuclides, and the second column the amount of each nuclide.
+
+An optional third column can be provided with the unit, which can differ for
+each nuclide. This makes it possible to load an inventory from mixed activity,
+moles or mass units for each nuclide.
+
+Example CSV file, saved as e.g. ``example_file.csv``:
+
+.. code-block:: text
+
+    nuclide|amount|units
+    C-14|5.0|Ci
+    H-3|0.2|g
+    He-3|1|mol
+
+Read command - ``skip_rows=1`` is required to ignore the header row:
+
+.. code-block:: python3
+
+    >>> inv = rd.read_csv('example_file.csv', delimiter='|', skip_rows=1)
 
 Radioactive decay calculations
 ------------------------------

--- a/radioactivedecay/__init__.py
+++ b/radioactivedecay/__init__.py
@@ -25,7 +25,7 @@ imported as ``rd``:
 
 """
 
-__version__ = "0.4.19"
+__version__ = "0.4.20"
 
 from radioactivedecay.decaydata import DEFAULTDATA, DecayData
 from radioactivedecay.fileio import read_csv

--- a/radioactivedecay/__init__.py
+++ b/radioactivedecay/__init__.py
@@ -28,5 +28,6 @@ imported as ``rd``:
 __version__ = "0.4.19"
 
 from radioactivedecay.decaydata import DEFAULTDATA, DecayData
+from radioactivedecay.fileio import read_csv
 from radioactivedecay.inventory import Inventory, InventoryHP
 from radioactivedecay.nuclide import Nuclide

--- a/radioactivedecay/fileio.py
+++ b/radioactivedecay/fileio.py
@@ -1,0 +1,161 @@
+"""
+The fileio module contains functions to create inventory instances by reading nuclide quantities
+from a file.
+
+The docstring code examples assume that ``radioactivedecay`` has been imported
+as ``rd``:
+
+.. highlight:: python
+.. code-block:: python
+
+    >>> import radioactivedecay as rd
+
+"""
+
+import csv
+import pathlib
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from radioactivedecay.decaydata import DecayData
+from radioactivedecay.inventory import Inventory, InventoryHP
+
+
+def _read_csv_file(
+    filepath: Union[str, pathlib.Path],
+    delimiter: str,
+    encoding: str,
+) -> List[List[str]]:
+    """Read CSV file. All file read side-effect is here to assist testing read_csv() with mock."""
+    with open(filepath, "r", encoding=encoding) as file:
+        reader_object = csv.reader(file, delimiter=delimiter)
+        lines = list(reader_object)
+
+    return lines
+
+
+def _parse_row(
+    row: List[str], default_unit: Optional[str]
+) -> Tuple[Dict[Union[str, int], float], Optional[str]]:
+    """Parse one row that should be nuclide, quantity (, unit) format."""
+
+    if len(row) not in {2, 3}:
+        raise ValueError(
+            f"This row of input file ('{row}') does not satisfy required format: i.e. nuclide, "
+            "quantity (, unit)."
+        )
+
+    nuc = row[0]
+    nuclide: Union[str, int] = int(nuc) if nuc.isnumeric() else nuc
+
+    quantity = float(row[1])
+
+    unit = default_unit
+    if len(row) == 3:
+        unit = row[2]
+
+    return {nuclide: quantity}, unit
+
+
+def read_csv(
+    filepath: Union[str, pathlib.Path],
+    inventory_type: str = "Inventory",
+    units: Optional[str] = None,
+    decay_data: Optional[DecayData] = None,
+    delimiter: str = ",",
+    skip_rows: int = 0,
+    encoding: str = "utf-8",
+) -> Union[Inventory, InventoryHP]:
+    """
+    Create an inventory by reading from a CSV file.
+
+    The CSV file must contain at least two columns. The first column must contain nuclide strings /
+    canonical ids. The second column must contain the quantities of each nuclide.
+
+    Optionally a third column may be included specifying the units of each nuclide's quantity. If a
+    unit is present on a row, it overrides the units set in the function parameter (i.e. ``units``
+    is ignored for that row).
+
+    A header row is not required. If the CSV file contains a header, you should ignore it using the
+    ``skip_rows`` parameter.
+
+    Example valid CSV file (no units - 'Bq' will be inferred by inventory constructor default):
+
+    .. code-block:: text
+
+        H-3,1.0
+        C-14,2.0
+
+    Example with tab separators (TSV format) and units specified:
+
+    .. code-block:: text
+
+        H-3 3.0 Bq
+        He-3    17.0   mol
+        C-14    5.0 Ci
+
+    Parameters
+    ----------
+    filepath : str or pathlib.Path
+        Name or path of the file to read in.
+    inventory_type : str, optional
+        The type of inventory you want to create. Either "Inventory" (default) for a normal
+        precision (SciPy) inventory, or "InventoryHP" for a high precision (SymPy) inventory.
+    units : None or str, optional
+        The units of all the nuclide quantities in the file. If a unit is specified on a row of the
+        file in the third column, that unit will override this one. If ``units = None`` is
+        specified (default) and there is no unit on the row, the default of the inventory
+        constructor will be used (currently 'Bq').
+    decay_data : None or DecayData, optional
+        The decay dataset to create the inventory with. If None is specified (default), the default
+        of the inventory constructor will be used (which currently is the ICRP-107 dataset).
+    delimiter : str, optional
+        The delimiter used to separate items in the file. Default is comma (",", CSV format).
+        Ex. if ``delimiter = "\t"`` (tab) will attempt to read a TSV file.
+    skip_rows : int, optional
+        Number of rows to ignore at the start of the file. Default is 0. Use this parameter
+        to ignore a header row if the file has one (e.g. ``nuclide,quantity,unit``).
+    encoding : str, optional
+        Encoding of the file. Default is 'utf-8'.
+
+    Raises
+    ------
+    ValueError
+        If the file or function parameters are invalid in some way: e.g. i) if a row does not
+        contain 2 (nuclide string/canonical id & quantity) or 3 values (if including unit), or ii)
+        skip_rows means end of file is reached, or iii) invalid ``inventory_type`` specified.
+
+    """
+
+    lines = _read_csv_file(filepath, delimiter, encoding)
+    lines_no_header = lines[skip_rows:]
+    if len(lines_no_header) == 0:
+        raise ValueError(
+            f"`skip_rows = {skip_rows}`, but file only contains {len(lines)} lines so there cannot"
+            " be any nuclide and quantity entries (rows) in the file."
+        )
+
+    contents, row_unit = _parse_row(lines_no_header[0], units)
+    kwargs: Dict[str, Any] = {"contents": contents}
+    if row_unit is not None or units is not None:
+        kwargs["units"] = row_unit or units
+    if decay_data is not None:
+        kwargs["decay_data"] = decay_data
+
+    if inventory_type == "Inventory":
+        inv: Union[Inventory, InventoryHP] = Inventory(**kwargs)
+    elif inventory_type == "InventoryHP":
+        inv = InventoryHP(**kwargs)
+    else:
+        raise ValueError(
+            f"`inventory_type` argument ('{inventory_type}') should either 'Inventory' or "
+            "'InventoryHP'"
+        )
+
+    for row in lines_no_header[1:]:
+        contents, row_unit = _parse_row(row, units)
+        kwargs = {"add_contents": contents}
+        if row_unit is not None or units is not None:
+            kwargs["units"] = row_unit or units
+        inv.add(**kwargs)
+
+    return inv

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -1,0 +1,135 @@
+"""
+Unit tests for fileio.py functions.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from radioactivedecay.decaydata import load_dataset
+from radioactivedecay.fileio import read_csv
+from radioactivedecay.inventory import Inventory, InventoryHP
+
+
+class TestReadCSV(unittest.TestCase):
+    """
+    Unit tests for the read_csv() function.
+    """
+
+    @patch("radioactivedecay.fileio._read_csv_file")
+    def test_inventory(self, mock__read_csv_file) -> None:
+        """Test normal inventory from file."""
+
+        mock__read_csv_file.return_value = [["H-3", "1"]]
+
+        inv = read_csv("fake_file.csv")
+        self.assertEqual(inv, Inventory({"H-3": 1.0}))
+
+    @patch("radioactivedecay.fileio._read_csv_file")
+    def test_multiple_rows(self, mock__read_csv_file) -> None:
+        """Test file with more than one nuclide."""
+
+        mock__read_csv_file.return_value = [["H-3", "1"], ["C-14", "2"]]
+
+        inv = read_csv("fake_file.csv")
+        self.assertEqual(inv, Inventory({"H-3": 1.0, "C-14": 2.0}))
+
+    @patch("radioactivedecay.fileio._read_csv_file")
+    def test_inventory_canonical_id(self, mock__read_csv_file) -> None:
+        """Test file with canonical id of nuclide."""
+        mock__read_csv_file.return_value = [["10030000", "1"]]
+
+        inv = read_csv("fake_file.csv")
+        self.assertEqual(inv, Inventory({"H-3": 1.0}))
+
+    @patch("radioactivedecay.fileio._read_csv_file")
+    def test_invalid_rows(self, mock__read_csv_file) -> None:
+        "Test file with invalid rows."
+
+        mock__read_csv_file.return_value = [["H-31"]]
+        with self.assertRaises(ValueError):
+            read_csv("fake_file.csv")
+
+        mock__read_csv_file.return_value = [["H-3,1,Bq,mol"]]
+        with self.assertRaises(ValueError):
+            read_csv("fake_file.csv")
+
+    @patch("radioactivedecay.fileio._read_csv_file")
+    def test_empty_file(self, mock__read_csv_file) -> None:
+        """Test catches empty file input."""
+
+        mock__read_csv_file.return_value = []
+        with self.assertRaises(ValueError):
+            read_csv("fake_file.csv")
+
+    @patch("radioactivedecay.fileio._read_csv_file")
+    def test_inventoryhp(self, mock__read_csv_file) -> None:
+        """Test high precision inventory from file."""
+
+        mock__read_csv_file.return_value = [["H-3", "1"]]
+
+        inv = read_csv("fake_file.csv", "InventoryHP")
+        self.assertEqual(inv, InventoryHP({"H-3": 1.0}))
+
+    @patch("radioactivedecay.fileio._read_csv_file")
+    def test_invalid_inventory_parameter(self, mock__read_csv_file) -> None:
+        """Test invalid inventory parameter."""
+
+        mock__read_csv_file.return_value = [["H-3", "1"]]
+
+        with self.assertRaises(ValueError):
+            read_csv("fake_file.csv", "random string")
+
+    @patch("radioactivedecay.fileio._read_csv_file")
+    def test_units_parameter(self, mock__read_csv_file) -> None:
+        """Test passing units as parameter."""
+
+        mock__read_csv_file.return_value = [["H-3", "1"]]
+
+        inv = read_csv("fake_file.csv", units="mol")
+        self.assertEqual(inv, Inventory({"H-3": 1.0}, "mol"))
+
+    @patch("radioactivedecay.fileio._read_csv_file")
+    def test_units_in_file(self, mock__read_csv_file) -> None:
+        """Test reading units from row in file."""
+
+        mock__read_csv_file.return_value = [["H-3", "1", "mol"]]
+
+        inv = read_csv("fake_file.csv", units="mol")
+        self.assertEqual(inv, Inventory({"H-3": 1.0}, "mol"))
+
+    @patch("radioactivedecay.fileio._read_csv_file")
+    def test_different_units_in_file(self, mock__read_csv_file) -> None:
+        """Test file with multiple nuclides, different units."""
+
+        mock__read_csv_file.return_value = [["H-3", "1", "Ci"], ["C-14", "2", "Bq"]]
+
+        inv = read_csv("fake_file.csv", units="mol")
+        self.assertEqual(inv, Inventory({"H-3": 3.7e10, "C-14": 2.0}, "Bq"))
+
+    @patch("radioactivedecay.fileio._read_csv_file")
+    def test_units_in_file_overrides(self, mock__read_csv_file) -> None:
+        """Test units in file overrides parameter set value."""
+
+        mock__read_csv_file.return_value = [["H-3", "1", "mol"]]
+
+        inv = read_csv("fake_file.csv", units="Ci")
+        self.assertEqual(inv, Inventory({"H-3": 1.0}, "mol"))
+
+    @patch("radioactivedecay.fileio._read_csv_file")
+    def test_decay_data_parameter(self, mock__read_csv_file) -> None:
+        """Test passing DecayData instance as parameter."""
+
+        mock__read_csv_file.return_value = [["H-3", "1"]]
+
+        decay_data = load_dataset("icrp107_ame2020_nubase2020", load_sympy=True)
+        inv = read_csv("fake_file.csv", decay_data=decay_data)
+        self.assertEqual(inv, Inventory({"H-3": 1.0}, decay_data=decay_data))
+
+    @patch("radioactivedecay.fileio._read_csv_file")
+    def test_skiprows_parameter(self, mock__read_csv_file) -> None:
+        """Test skipping rows at head of file."""
+
+        mock__read_csv_file.return_value = [["header"], ["H-3", "1"]]
+
+        inv = read_csv("fake_file.csv", skip_rows=1)
+        self.assertEqual(inv, Inventory({"H-3": 1.0}))


### PR DESCRIPTION
<!-- Thank you for contributing a Pull Request! Please ensure you also check the contributor guidelines:
https://github.com/radioactivedecay/radioactivedecay/blob/main/CONTRIBUTING.md -->

#### What does this PR implement/fix?

 `rd.read_csv()` creates an inventory from a CSV file of nuclides, quantities and (optionally) units. The function's parameters includes options to set the type of inventory created (normal or high-precision), units (if none are provided in the CSV file, otherwise the units written in the CSV file take preference), the decay dataset, delimiter (comma, tab, pipe etc.), the number of header rows to skip, and the file encoding.

For more see the API docs that will go live here: https://radioactivedecay.github.io/fileio.html

Cuts a new release (`v0.4.20`) to get this out into the wild.


#### Fixes Issue
#94 


#### Other comments?
At some point I'll make a `.to_csv()` method for the inventory classes to export the contents to a CSV file.