### PR TITLE
Add method for writing an inventory to a CSV file, Release 0.4.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.21] - 2023-08-13
+- Add `Inventory.to_csv()` and `InventoryHP.to_csv()` methods for writing an inventory's contents
+to a CSV file (in user's chosen units) (#94).
+
 ## [0.4.20] - 2023-08-08
 - Add `rd.read_csv()` function for creating an inventory by reading nuclides & quantities (and
 optionally units) in from a CSV file (#94).

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2022 Japan Atomic Energy Agency
+Copyright (c) 2020-2023 Japan Atomic Energy Agency & contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,7 +20,7 @@ sys.setrecursionlimit(1500)
 # -- Project information -----------------------------------------------------
 
 project = "radioactivedecay"
-copyright = "2022, JAEA"
+copyright = "2023, JAEA"
 author = "Alex Malins"
 
 # The full version, including alpha/beta/rc tags

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -446,3 +446,24 @@ constant as follows:
     >>> inv.numbers()
     {'Sr-90': 1.0, 'Cs-137': 1.0} 
 
+Writing results to a file
+-------------------------
+
+Similar to ``rd.read_csv()``, inventory objects have a ``.to_csv()`` method for
+writing out the contents of an inventory to a CSV-type file. The user specifies
+the filename, the units to be used, whether the units should be written into
+the file (via the third column), the delimiter e.g. comma for a CSV file,
+tab (``'\t'``) for a TSV file, and the header line for the file:
+
+.. code-block:: python3
+
+    >>> inv = rd.Inventory({'Cs-137': 1.02, 'Sr-90': 3.05}, 'Bq')
+    >>> inv.to_csv('test_output.csv', units='mBq', delimiter='|', write_units=True, header=["nuclide", "quantity", "units"])
+
+This produces a file named "test_output.csv" containing:
+
+.. code-block:: text
+
+    nuclide|amount|units
+    Cs-137|1020.0|mBq
+    Sr-90|3050.0|mBq

--- a/radioactivedecay/__init__.py
+++ b/radioactivedecay/__init__.py
@@ -25,7 +25,7 @@ imported as ``rd``:
 
 """
 
-__version__ = "0.4.20"
+__version__ = "0.4.21"
 
 from radioactivedecay.decaydata import DEFAULTDATA, DecayData
 from radioactivedecay.fileio import read_csv

--- a/radioactivedecay/fileio.py
+++ b/radioactivedecay/fileio.py
@@ -98,8 +98,8 @@ def read_csv(
     filepath : str or pathlib.Path
         Name or path of the file to read in.
     inventory_type : str, optional
-        The type of inventory you want to create. Either "Inventory" (default) for a normal
-        precision (SciPy) inventory, or "InventoryHP" for a high precision (SymPy) inventory.
+        The type of inventory you want to create. Either 'Inventory' (default) for a normal
+        precision (SciPy) inventory, or 'InventoryHP' for a high precision (SymPy) inventory.
     units : None or str, optional
         The units of all the nuclide quantities in the file. If a unit is specified on a row of the
         file in the third column, that unit will override this one. If ``units = None`` is
@@ -109,8 +109,8 @@ def read_csv(
         The decay dataset to create the inventory with. If None is specified (default), the default
         of the inventory constructor will be used (which currently is the ICRP-107 dataset).
     delimiter : str, optional
-        The delimiter used to separate items in the file. Default is comma (",", CSV format).
-        Ex. if ``delimiter = "\t"`` (tab) will attempt to read a TSV file.
+        The delimiter used to separate items in the file. Default is comma (',', CSV format).
+        Ex. if ``delimiter = '\t'`` (tab) will attempt to read a TSV file.
     skip_rows : int, optional
         Number of rows to ignore at the start of the file. Default is 0. Use this parameter
         to ignore a header row if the file has one (e.g. ``nuclide,quantity,unit``).

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -669,6 +669,82 @@ class TestInventory(unittest.TestCase):
         with self.assertRaises(ValueError):
             inv.plot(100, "ky", yunits="invalid")
 
+    @patch("radioactivedecay.inventory._write_csv_file")
+    def test_to_csv_invalid_units(self, mock__write_csv_file) -> None:
+        """
+        Test writing Inventory to csv file with invalid units.
+        """
+
+        inv = Inventory({"H-3": 10.0, "14C": 50.0})
+        with self.assertRaises(ValueError):
+            inv.to_csv("test_file.csv", units="fake")
+
+    @patch("radioactivedecay.inventory._write_csv_file")
+    def test_to_csv_write_units(self, mock__write_csv_file) -> None:
+        """
+        Test writing Inventory to csv file including writing units.
+        """
+
+        inv = Inventory({"H-3": 10.0, "14C": 50.0})
+        kwargs = {
+            "filename": "test_file.csv",
+            "delimiter": "\t",
+            "write_units": True,
+            "encoding": "utf-16",
+        }
+        inv.to_csv(**kwargs)
+        mock__write_csv_file.assert_called_once_with(
+            kwargs["filename"],
+            [["C-14", "50.0", "Bq"], ["H-3", "10.0", "Bq"]],
+            kwargs["delimiter"],
+            kwargs["encoding"],
+        )
+
+    @patch("radioactivedecay.inventory._write_csv_file")
+    def test_to_csv_dont_write_units(self, mock__write_csv_file) -> None:
+        """
+        Test writing Inventory to csv file without writing units.
+        """
+
+        inv = Inventory({"H-3": 10.0}, "kg")
+        kwargs = {
+            "filename": "test_file.csv",
+            "units": "g",
+        }
+        inv.to_csv(**kwargs)
+        mock__write_csv_file.assert_called_with(
+            kwargs["filename"],
+            [["H-3", "10000.0"]],
+            ",",
+            "utf-8",
+        )
+
+        inv = Inventory({"H-3": 20.2}, "mol")
+        kwargs = {
+            "filename": "test_file.csv",
+            "units": "mmol",
+        }
+        inv.to_csv(**kwargs)
+        mock__write_csv_file.assert_called_with(
+            kwargs["filename"],
+            [["H-3", "20200.0"]],
+            ",",
+            "utf-8",
+        )
+
+        inv = Inventory({"H-3": 20.2}, "num")
+        kwargs = {
+            "filename": "test_file.csv",
+            "units": "num",
+        }
+        inv.to_csv(**kwargs)
+        mock__write_csv_file.assert_called_with(
+            kwargs["filename"],
+            [["H-3", "20.2"]],
+            ",",
+            "utf-8",
+        )
+
     def test___eq__(self) -> None:
         """
         Test Inventory equality.
@@ -928,6 +1004,32 @@ class TestInventoryHP(unittest.TestCase):
         self.assertEqual(axes.get_xlim()[0], 0.0707945784384138)
         self.assertEqual(axes.get_ylim(), (949.999999633917, 2100.0))
         self.assertEqual(axes.get_legend_handles_labels()[-1], ["K-40", "C-14"])
+
+    @patch("radioactivedecay.inventory._write_csv_file")
+    def test_to_csv_write_units(self, mock__write_csv_file) -> None:
+        """
+        Test writing Inventory to csv file including writing units.
+        """
+
+        inv = InventoryHP({"H-3": 10.0, "14C": 50.0})
+        kwargs = {
+            "filename": "test_file.csv",
+            "delimiter": "\t",
+            "write_units": True,
+            "header": ["nuclide", "quantity", "units"],
+            "encoding": "utf-16",
+        }
+        inv.to_csv(**kwargs)
+        mock__write_csv_file.assert_called_once_with(
+            kwargs["filename"],
+            [
+                ["nuclide", "quantity", "units"],
+                ["C-14", "50.0", "Bq"],
+                ["H-3", "10.0", "Bq"],
+            ],
+            kwargs["delimiter"],
+            kwargs["encoding"],
+        )
 
     def test___repr__(self) -> None:
         """


### PR DESCRIPTION
<!-- Thank you for contributing a Pull Request! Please ensure you also check the contributor guidelines:
https://github.com/radioactivedecay/radioactivedecay/blob/main/CONTRIBUTING.md -->

#### What does this PR implement/fix?
New feature: adds a `.to_csv()` method to `Inventory` and `InventoryHP` objects for writing out the contents of the inventory to a CSV file in the users chosen units.

#### Fixes Issue
cf. #94 and #97


#### Other comments?
