### PR TITLE
Correct method name in plotting documentation

### DIFF
--- a/docs/source/plotting.rst
+++ b/docs/source/plotting.rst
@@ -93,7 +93,7 @@ with your own Matplotlib parameters, e.g. to save a PNG image:
 For more information on handling the figure and axes objects, see the
 `Matplotlib documentation <https://matplotlib.org/contents.html>`_.
 
-To control which progeny are plotted, the ``calculate_decay_data()`` method can
+To control which progeny are plotted, the ``decay_time_series_pandas()`` method can
 be use to extract the data into a pandas dataframe which can be filtered as required
 then plotted directly. As the plot method of a dataframe is a `wrapper around Matplotlib
 <https://pandas.pydata.org/docs/user_guide/visualization.html#basic-plotting-plot>`_,
@@ -103,7 +103,7 @@ the returned axes object can be used and manipulated in the usual way (see the
 .. code-block:: python3
 
    >>> inv = rd.Inventory({'U-238': 2000.0, 'U-235': 3000.0, 'U-234': 1500.0}, 'num')
-   >>> df = inv.calculate_decay_data(time_period=1E9, time_units='y', decay_units='num')
+   >>> df = inv.decay_time_series_pandas(time_period=1E9, time_units='y', decay_units='num')
    >>> df.plot(ylabel='Number of Particles')
 
 .. image:: images/U_decay.png


### PR DESCRIPTION
The old method name was left in the plotting documentation file, update to the correct name.

<!-- Thank you for contributing a Pull Request! Please ensure you also check the contributor guidelines:
https://github.com/radioactivedecay/radioactivedecay/blob/main/CONTRIBUTING.md -->

#### What does this PR implement/fix?
Fix typos in documentation

#### Fixes Issue
N/A

#### Other comments?
I thought pushing this branch would re-open #104. Guess not so this new PR has been created.
