### PR TITLE
Release 0.5.0

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -11,8 +11,8 @@ Note if you have a general usage question or feature request, please use the Dis
 
 #### Environment
 OS version: <!-- Windows 10/Linux/macOS etc. -->
-Python version: <!-- 3.6/3.7/3.8/3.9/3.10/3.11/3.12 -->
-radioactivedecay version: <!-- ex. 0.4.16 -->
+Python version: <!-- 3.8/3.9/3.10/3.11/3.12 -->
+radioactivedecay version: <!-- ex. 0.5.0 -->
 Installed via: <!-- pip/conda-forge -->
 
 

--- a/.github/workflows/1_tests.yml
+++ b/.github/workflows/1_tests.yml
@@ -19,8 +19,8 @@ jobs:
         include:
           - os: windows-latest
             python-version: '3.12'
-          #- os: macos-latest
-          #  python-version: '3.12'
+          - os: macos-latest
+            python-version: '3.12'
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/1_tests.yml
+++ b/.github/workflows/1_tests.yml
@@ -15,12 +15,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         include:
           - os: windows-latest
             python-version: '3.12'
           #- os: macos-latest
-          #  python-version: '3.7'
+          #  python-version: '3.12'
     timeout-minutes: 10
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## [0.4.22] - 2024-??-??
+## [0.5.0] - 2024-04-20
 - Add `Inventory.decay_time_series_pandas()` method to save decay data into a pandas dataframe. Time
-resolution is specified by the user.
+resolution is specified by the user (#104).
 - Add `Inventory.decay_time_series()` method to access the decay data create by `decay_time_series_pandas()`
-as a list for the time data and dictionary for the isotopic data.
+as a list for the time data and dictionary for the isotopic data (#104).
 
 ## [0.4.22] - 2024-01-27
 - Added explicit support for Python v3.12. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 resolution is specified by the user (#104).
 - Add `Inventory.decay_time_series()` method to access the decay data create by `decay_time_series_pandas()`
 as a list for the time data and dictionary for the isotopic data (#104).
-- Drop support for end-of-life Python versions v3.6 & v3.7 (#106). 
+- Drop support for end-of-life Python versions v3.6 & v3.7 (#106).
+- Fix `pkg_resources` deprecation warnings and some pylint warnings (#106).
 
 ## [0.4.22] - 2024-01-27
 - Added explicit support for Python v3.12. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 resolution is specified by the user (#104).
 - Add `Inventory.decay_time_series()` method to access the decay data create by `decay_time_series_pandas()`
 as a list for the time data and dictionary for the isotopic data (#104).
+- Drop support for end-of-life Python versions v3.6 & v3.7 (#106). 
 
 ## [0.4.22] - 2024-01-27
 - Added explicit support for Python v3.12. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ warnings that are raised.
 
 ### Type Hints
 
-This project requires Python 3.6+ and type hints are included in the headers of
+This project requires Python 3.8+ and type hints are included in the headers of
 all functions and methods exposed to users. Please add type hints for any new
 functions you create.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2023 Japan Atomic Energy Agency & contributors
+Copyright (c) 2020-2024 Japan Atomic Energy Agency & contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ educational use.
 
 ## Installation
 
-``radioactivedecay`` requires Python 3.6+. Install ``radioactivedecay`` from
+``radioactivedecay`` requires Python 3.8+. Install ``radioactivedecay`` from
 the [Python Package Index](https://pypi.org/project/radioactivedecay/) using
 ``pip``:
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ $ conda install -c conda-forge radioactivedecay
 ```
 
 Either command will attempt to install the dependencies (Matplotlib, NetworkX,
-NumPy, SciPy, Setuptools & SymPy) if they are not already present in the
-environment.
+NumPy, Pandas, SciPy, Setuptools & SymPy) if they are not already present in
+the environment.
 
 
 ## Usage

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,7 +4,7 @@ Installation
 Prerequisites
 -------------
 
-``radioactivedecay`` requires Python 3.6+ and the `Matplotlib
+``radioactivedecay`` requires Python 3.8+ and the `Matplotlib
 <https://matplotlib.org/>`_, `NetworkX
 <https://networkx.org/>`_, `NumPy <https://numpy.org/>`_,
 `Pandas <https://pandas.pydata.org/>`_,

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -7,6 +7,7 @@ Prerequisites
 ``radioactivedecay`` requires Python 3.6+ and the `Matplotlib
 <https://matplotlib.org/>`_, `NetworkX
 <https://networkx.org/>`_, `NumPy <https://numpy.org/>`_,
+`Pandas <https://pandas.pydata.org/>`_,
 `SciPy <https://www.scipy.org/index.html>`_,
 `Setuptools <https://setuptools.pypa.io/en/latest/>`_ and 
 `SymPy <https://www.sympy.org>`_ packages. These can be
@@ -33,8 +34,8 @@ or via `conda-forge <https://anaconda.org/conda-forge/radioactivedecay>`_:
     $ conda install -c conda-forge radioactivedecay
 
 Either command will attempt to install the dependencies (Matplotlib, NetworkX,
-NumPy, SciPy, Setuptools & SymPy) if they are not already present in the
-environment.
+NumPy, Pandas, SciPy, Setuptools & SymPy) if they are not already present in
+the environment.
 
 It is also possible to clone the GitHub `repository 
 <https://github.com/radioactivedecay/radioactivedecay>`_ and install from within the

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -17,7 +17,7 @@ Atomic Mass Data Center (AME2020 and Nubase 2020 evaluations)
 decay differential equations analytically using basic linear algebra operations
 :ref:`[5] <refs>`.
 
-In order to use ``radioactivedecay``, you will need Python 3.6+ with the
+In order to use ``radioactivedecay``, you will need Python 3.8+ with the
 Matplotlib, NetworkX, NumPy, Pandas, SciPy, Setuptools and SymPy packages
 installed. The code is platform independent and has been tested on Windows,
 MacOS and Linux systems.

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -18,9 +18,9 @@ decay differential equations analytically using basic linear algebra operations
 :ref:`[5] <refs>`.
 
 In order to use ``radioactivedecay``, you will need Python 3.6+ with the
-Matplotlib, NetworkX, NumPy, SciPy, Setuptools and SymPy packages installed.
-The code is platform independent and has been tested on Windows, MacOS and
-Linux systems.
+Matplotlib, NetworkX, NumPy, Pandas, SciPy, Setuptools and SymPy packages
+installed. The code is platform independent and has been tested on Windows,
+MacOS and Linux systems.
 
 Quick start
 -----------
@@ -38,8 +38,8 @@ or using ``conda`` by:
     $ conda install -c conda-forge radioactivedecay
 
 Either command will attempt to install the dependencies (Matplotlib, NetworkX,
-NumPy, SciPy, Setuptooks & SymPy) if they are not already present in the
-environment.
+NumPy, Pandas, SciPy, Setuptooks & SymPy) if they are not already present in
+the environment.
 
 Import the ``radioactivedecay`` package and decay a simple inventory using:
 
@@ -121,7 +121,8 @@ the method described in ref. :ref:`[5] <refs>`.  See the
 :doc:`theory docpage <theory>` for
 more details. It calls NumPy :ref:`[6] <refs>` and SciPy :ref:`[7] <refs>` for
 the matrix operations. There is also a high numerical precision decay
-calculation mode based on SymPy :ref:`[8] <refs>` routines.
+calculation mode based on SymPy :ref:`[8] <refs>` routines. Decay time series
+data can be output as a Pandas :ref:`[9] <refs>` dataframes.
 
 The `datasets repo
 <https://github.com/radioactivedecay/datasets>`_ 
@@ -131,9 +132,9 @@ on GitHub contains a Jupyter Notebook for creating the
 Notebooks with cross-checks of decay calculation results against
 `PyNE
 <https://github.com/radioactivedecay/comparisons/blob/main/pyne/rd_pyne_truncated_compare.ipynb>`_ 
-:ref:`[9] <refs>` and `Radiological Toolbox 
+:ref:`[10] <refs>` and `Radiological Toolbox 
 <https://github.com/radioactivedecay/comparisons/blob/main/radiological_toolbox/radiological_toolbox_compare.ipynb>`_
-:ref:`[10] <refs>` are held in the `comparisons repo
+:ref:`[11] <refs>` are held in the `comparisons repo
 <https://github.com/radioactivedecay/comparisons>`_. 
 
 Limitations
@@ -168,7 +169,7 @@ There are also some limitations associated with the ICRP-107 decay dataset:
 * There are a few instances where minor decay pathways were not included in
   ICRP-107, e.g. the decay pathways for At-219-> Rn-219 (|beta| ~3%), Es-250 ->
   Bk-246 (|alpha| ~1.5%), and U-228 -> Pa-228 (|epsilon| ~2.5%). For more
-  details see refs. :ref:`[11] <refs>` and :ref:`[12] <refs>` on the creation of
+  details see refs. :ref:`[12] <refs>` and :ref:`[13] <refs>` on the creation of
   the ICRP-107 dataset.
 
 License
@@ -210,6 +211,7 @@ List of contributors to ``radioactivedecay``:
 * `Alex Malins <https://alexmalins.com>`_
 * `Thom Lemoine <https://github.com/lemointm>`_
 * `Bernardo Gameiro <https://bgameiro.me/>`_
+* `Ian Cullen <https://github.com/php1ic>`_
 
 
 Contributing
@@ -254,7 +256,7 @@ for suggestions, support and assistance to this project.
 Thanks also to:
 
 * `Björn Dahlgren <https://github.com/bjodah>`_ (creator of the batemaneq
-  Python package :ref:`[13] <refs>`)
+  Python package :ref:`[14] <refs>`)
 * `Anthony Scopatz <https://github.com/scopatz>`_ and the PyNE project
   :ref:`[9] <refs>`
 * `Jonathan Morrell <https://github.com/jtmorrell>`_ (creator of the `NPAT
@@ -262,7 +264,7 @@ Thanks also to:
   <https://github.com/jtmorrell/npat>`_ packages)
 * `Austin Ladshaw <https://www.researchgate.net/profile/Austin-Ladshaw>`_ &
   collaborators (creators of `IBIS
-  <https://bitbucket.org/gitecosystem/ecosystem>`_ :ref:`[14] <refs>`)
+  <https://bitbucket.org/gitecosystem/ecosystem>`_ :ref:`[15] <refs>`)
 * `Will Johnson <https://github.com/wcjohns>`_ & collaborators (creators of
   `SandiaDecay <https://github.com/sandialabs/SandiaDecay>`_)
 
@@ -281,12 +283,13 @@ References
 6. CR Harris et al. Nat. 585, 357-362 (2020). DOI: `10.1038/s41586-020-2649-2 <https://doi.org/10.1038/s41586-020-2649-2>`_
 7. P Virtanen et al. Nat. Methods 17, 261-272 (2020). DOI: `10.1038/s41592-019-0686-2 <https://doi.org/10.1038/s41592-019-0686-2>`_
 8. A Meurer et al. PeerJ Comp. Sci. 3, e103 (2017). DOI: `10.7717/peerj-cs.103 <https://doi.org/10.7717/peerj-cs.103>`_
-9. PyNE: The Nuclear Engineering Toolkit. `https://pyne.io/ <https://pyne.io/>`_
-10. KF Eckerman, AL Sjoreen & C Sun, Radiological Toolbox, Oak Ridge National Laboratory. `https://www.ornl.gov/crpk/software <https://www.ornl.gov/crpk/software>`_
-11. A Endo, Y Yamaguchi & KF Eckerman, JAERI 1347 (2005). DOI: `10.11484/jaeri-1347 <https://doi.org/10.11484/jaeri-1347>`_
-12. A Endo & KF Eckerman, JAEA-Data/Code 2007-021 (2007). DOI: `10.11484/jaea-data-code-2007-021 <https://doi.org/10.11484/jaea-data-code-2007-021>`_
-13. B Dahlgren, batemaneq:  a C++ implementation of the Bateman equation, and a Python binding thereof. `https://github.com/bjodah/batemaneq <https://github.com/bjodah/batemaneq>`_
-14. A Ladshaw et al. Comput. Phys. Comm. 246, 106907 (2020). DOI: `10.1016/j.cpc.2019.106907 <https://doi.org/10.1016/j.cpc.2019.106907>`_
+9. The pandas development team (2020). DOI: `10.5281/zenodo.3509134 <https://doi.org/10.5281/zenodo.3509134>`_
+10. PyNE: The Nuclear Engineering Toolkit. `https://pyne.io/ <https://pyne.io/>`_
+11. KF Eckerman, AL Sjoreen & C Sun, Radiological Toolbox, Oak Ridge National Laboratory. `https://www.ornl.gov/crpk/software <https://www.ornl.gov/crpk/software>`_
+12. A Endo, Y Yamaguchi & KF Eckerman, JAERI 1347 (2005). DOI: `10.11484/jaeri-1347 <https://doi.org/10.11484/jaeri-1347>`_
+13. A Endo & KF Eckerman, JAEA-Data/Code 2007-021 (2007). DOI: `10.11484/jaea-data-code-2007-021 <https://doi.org/10.11484/jaea-data-code-2007-021>`_
+14. B Dahlgren, batemaneq:  a C++ implementation of the Bateman equation, and a Python binding thereof. `https://github.com/bjodah/batemaneq <https://github.com/bjodah/batemaneq>`_
+15. A Ladshaw et al. Comput. Phys. Comm. 246, 106907 (2020). DOI: `10.1016/j.cpc.2019.106907 <https://doi.org/10.1016/j.cpc.2019.106907>`_
 
 .. |alpha| unicode:: U+03B1 .. lower case alpha
 .. |beta| unicode:: U+03B2 .. lower case beta

--- a/radioactivedecay/__init__.py
+++ b/radioactivedecay/__init__.py
@@ -25,7 +25,7 @@ imported as ``rd``:
 
 """
 
-__version__ = "0.4.22"
+__version__ = "0.5.0"
 
 from radioactivedecay.decaydata import DEFAULTDATA, DecayData
 from radioactivedecay.fileio import read_csv

--- a/radioactivedecay/decaydata.py
+++ b/radioactivedecay/decaydata.py
@@ -28,8 +28,8 @@ from abc import ABC, abstractmethod
 from typing import Any, Optional, Union
 
 import numpy as np
-import pkg_resources
 import sympy
+from packaging import version
 from scipy import sparse
 from sympy import Matrix
 from sympy.core.expr import Expr
@@ -41,9 +41,9 @@ from radioactivedecay.utils import parse_nuclide
 # importlib.resources API from Python version 3.9+ is used
 # this block adds support using a backport for Python <3.9
 # the importlib_resources dependency can be removed once min required Python version is 3.9
-if pkg_resources.parse_version(
+if version.Version(
     platform.python_version()
-) >= pkg_resources.parse_version("3.9"):
+) >= version.Version("3.9"):
     from importlib import resources
 else:
     import importlib_resources as resources  # type:ignore
@@ -778,8 +778,8 @@ def load_dataset(
     if load_sympy:
         sympy_pickle_version = (
             "1.8"
-            if pkg_resources.parse_version(sympy.__version__)
-            < pkg_resources.parse_version("1.9")
+            if version.Version(sympy.__version__)
+            < version.Version("1.9")
             else "1.9"
         )
 

--- a/radioactivedecay/decaydata.py
+++ b/radioactivedecay/decaydata.py
@@ -41,9 +41,7 @@ from radioactivedecay.utils import parse_nuclide
 # importlib.resources API from Python version 3.9+ is used
 # this block adds support using a backport for Python <3.9
 # the importlib_resources dependency can be removed once min required Python version is 3.9
-if version.Version(
-    platform.python_version()
-) >= version.Version("3.9"):
+if version.Version(platform.python_version()) >= version.Version("3.9"):
     from importlib import resources
 else:
     import importlib_resources as resources  # type:ignore
@@ -778,8 +776,7 @@ def load_dataset(
     if load_sympy:
         sympy_pickle_version = (
             "1.8"
-            if version.Version(sympy.__version__)
-            < version.Version("1.9")
+            if version.Version(sympy.__version__) < version.Version("1.9")
             else "1.9"
         )
 

--- a/radioactivedecay/inventory.py
+++ b/radioactivedecay/inventory.py
@@ -980,14 +980,14 @@ class AbstractInventory(ABC):
         Examples
         --------
         >>> inv = rd.Inventory({'C-14': 1.0})
-        >>> time, data = inv.calculate_decay_data(time_period=10, time_units="ky", decay_units="mass_frac", npoints=4)
+        >>> time, data = inv.decay_time_series_pandas(time_period=10, time_units="ky", decay_units="mass_frac", npoints=4)
         >>> time
         [0.0, 3.3333333333333335, 6.666666666666667, 10.0]
         >>> data
         {'C-14': [1.0, 0.6667465897861368, 0.4445504227269143, 0.2964018201597633], 'N-14': [0.0, 0.3332534102138631, 0.5554495772730857, 0.7035981798402366]}
 
         """
-        df = self.calculate_decay_data(
+        df = self.decay_time_series_pandas(
             time_period=time_period,
             time_units=time_units,
             time_scale=time_scale,

--- a/radioactivedecay/nuclide.py
+++ b/radioactivedecay/nuclide.py
@@ -363,9 +363,11 @@ class Nuclide:
         if "font_size" not in kwargs_edge_labels:
             kwargs_edge_labels["font_size"] = 12
         if "bbox" not in kwargs_edge_labels:
-            kwargs_edge_labels["bbox"] = dict(
-                boxstyle=None, ec=(1.0, 1.0, 1.0), fc=(1.0, 1.0, 1.0)
-            )
+            kwargs_edge_labels["bbox"] = {
+                "boxstyle": None,
+                "ec": (1.0, 1.0, 1.0),
+                "fc": (1.0, 1.0, 1.0),
+            }
         if "rotate" not in kwargs_edge_labels:
             kwargs_edge_labels["rotate"] = False
 
@@ -462,8 +464,7 @@ def _build_decay_digraph(
         branching_fractions = parent.branching_fractions()
         decay_modes = parent.decay_modes()
 
-        if xpos < generation_max_xpos[generation] + 1:
-            xpos = generation_max_xpos[generation] + 1
+        xpos = max(xpos, generation_max_xpos[generation] + 1)
         xcounter = 0
         for idx, prog in enumerate(progeny):
             if prog not in seen:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = radioactivedecay
 version = attr: radioactivedecay.__version__
-author = Alex Malins, Thom Lemoine, & contributors
+author = Alex Malins, Thom Lemoine, Ian Cullen & contributors
 author_email = github@alexmalinsREMOVETHIS.com
 license = MIT, ICRP-07, AMDC
 license_files = LICENSE, LICENSE.ICRP-07, LICENSE.AMDC

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,8 +20,6 @@ project_urls =
 classifiers = 
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -38,7 +36,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.8
 install_requires =
     matplotlib
     networkx

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -647,7 +647,7 @@ class TestInventory(unittest.TestCase):
             )
         )
 
-    def decay_time_series(self) -> None:
+    def test_decay_time_series(self) -> None:
         """
         Test method to fetch decay data of nuclides in the Inventory as list and dict tuple
         """


### PR DESCRIPTION
<!-- Thank you for contributing a Pull Request! Please ensure you also check the contributor guidelines:
https://github.com/radioactivedecay/radioactivedecay/blob/main/CONTRIBUTING.md -->

#### What does this PR implement/fix?

- Releases v0.5.0 with new Inventory decay time series methods
- Fix `pkg_resources` deprecated warnings
- Drop support for end-of-life Python 3.6 & 3.7
- Fix some pylint warnings


#### Fixes Issue



#### Other comments?
