### PR TITLE
Fix tests for NumPy NEP 51 representation strings, release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.5.1] - 2024-06-18
+- Fix tests to work with NumPy 2.0.0 NEP 51 string representations of NumPy data types (#107).
+
 ## [0.5.0] - 2024-04-20
 - Add `Inventory.decay_time_series_pandas()` method to save decay data into a pandas dataframe. Time
 resolution is specified by the user (#104).

--- a/radioactivedecay/__init__.py
+++ b/radioactivedecay/__init__.py
@@ -25,7 +25,7 @@ imported as ``rd``:
 
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 from radioactivedecay.decaydata import DEFAULTDATA, DecayData
 from radioactivedecay.fileio import read_csv

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -20,6 +20,9 @@ from radioactivedecay.nuclide import Nuclide
 # pylint: disable=protected-access, too-many-public-methods
 
 
+np.set_printoptions(legacy="1.25")
+
+
 def warning_message_if_dict_not_equal(
     calculated: Dict[str, float], expected: Dict[str, float]
 ) -> None:


### PR DESCRIPTION
<!-- Thank you for contributing a Pull Request! Please ensure you also check the contributor guidelines:
https://github.com/radioactivedecay/radioactivedecay/blob/main/CONTRIBUTING.md -->

#### What does this PR implement/fix?
Fixes the tests to work with NumPy 2.0.0, which introduced NEP 51 representation strings.

Release 0.5.1

#### Fixes Issue
N/A


#### Other comments?
