### PR TITLE
Fix tests SymPy 1.13.2 float integer zero comparison

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -12,7 +12,7 @@ Note if you have a general usage question or feature request, please use the Dis
 #### Environment
 OS version: <!-- Windows 10/Linux/macOS etc. -->
 Python version: <!-- 3.8/3.9/3.10/3.11/3.12 -->
-radioactivedecay version: <!-- ex. 0.5.0 -->
+radioactivedecay version: <!-- ex. 0.5.1 -->
 Installed via: <!-- pip/conda-forge -->
 
 

--- a/tests/test_decaydata.py
+++ b/tests/test_decaydata.py
@@ -144,17 +144,17 @@ class TestDecayMatricesSympy(unittest.TestCase):
         decay_mats = decaydata.DecayMatricesSympy(
             atomic_masses, decay_consts, matrix_c, matrix_c_inv
         )
-        self.assertEqual(decay_mats.atomic_masses[0], 0.0)
-        self.assertEqual(decay_mats.atomic_masses[1], 0.0)
-        self.assertEqual(decay_mats.decay_consts[0], 0.0)
-        self.assertEqual(decay_mats.decay_consts[1], 0.0)
+        self.assertEqual(decay_mats.atomic_masses[0], Integer(0))
+        self.assertEqual(decay_mats.atomic_masses[1], Integer(0))
+        self.assertEqual(decay_mats.decay_consts[0], Integer(0))
+        self.assertEqual(decay_mats.decay_consts[1], Integer(0))
         self.assertEqual(decay_mats.ln2, log(2))
         self.assertEqual(decay_mats.matrix_c[0, 0], Integer(2))
         self.assertEqual(decay_mats.matrix_c_inv[1, 1], Integer(3))
         self.assertEqual(decay_mats.matrix_e[0, 0], Integer(0))
         self.assertEqual(decay_mats.matrix_e[1, 1], Integer(0))
-        self.assertEqual(decay_mats.vector_n0[0], 0.0)
-        self.assertEqual(decay_mats.vector_n0[1], 0.0)
+        self.assertEqual(decay_mats.vector_n0[0], Integer(0))
+        self.assertEqual(decay_mats.vector_n0[1], Integer(0))
 
     def test___eq__(self) -> None:
         """


### PR DESCRIPTION
<!-- Thank you for contributing a Pull Request! Please ensure you also check the contributor guidelines:
https://github.com/radioactivedecay/radioactivedecay/blob/main/CONTRIBUTING.md -->

#### What does this PR implement/fix?

Fixes test failures like:

```
_______________________________________________________ TestDecayMatricesSympy.test_instantiation _______________________________________________________

self = <tests.test_decaydata.TestDecayMatricesSympy testMethod=test_instantiation>

    def test_instantiation(self) -> None:
        """
        Test instantiation of DecayMatricesSympy objects.
        """
    
        atomic_masses = Matrix.zeros(2, 1)
        decay_consts = Matrix.zeros(2, 1)
        matrix_c = SparseMatrix.zeros(2, 2)
        matrix_c[0, 0] = Integer(2)
        matrix_c_inv = SparseMatrix.zeros(2, 2)
        matrix_c_inv[1, 1] = Integer(3)
        decay_mats = decaydata.DecayMatricesSympy(
            atomic_masses, decay_consts, matrix_c, matrix_c_inv
        )
>       self.assertEqual(decay_mats.atomic_masses[0], 0.0)
E       AssertionError: 0 != 0.0

tests/test_decaydata.py:147: AssertionError
```

These were caused because the latest version of SymPy v1.13.2 now considers `Integer(0) != Float(0)`:

https://github.com/sympy/sympy/wiki/release-notes-for-1.13.2
https://github.com/sympy/sympy/pull/26948

#### Fixes Issue
N/A


#### Other comments?
