### PR TITLE
Fix import errors on Python 3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.6.1] - 2025-01-09
+- Fix `TypeError: expected str, bytes or os.PathLike object, not NoneType` errors on import with
+Python 3.9 (#117 & #118)
+
 ## [0.6.0] - 2025-01-08
 - Modernize build system using a single `pyproject.toml` (#115).
 - Drop Python 3.8 support and add Python 3.13 support (#115).

--- a/radioactivedecay/__init__.py
+++ b/radioactivedecay/__init__.py
@@ -25,7 +25,7 @@ imported as ``rd``:
 
 """
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 from radioactivedecay.decaydata import DEFAULTDATA, DecayData
 from radioactivedecay.fileio import read_csv

--- a/radioactivedecay/decaydata.py
+++ b/radioactivedecay/decaydata.py
@@ -629,7 +629,7 @@ def _get_package_filepath(subpackage_dir: str, filename: str) -> pathlib.Path:
 
     """
 
-    return resources.files(f"{__package__}.{subpackage_dir}").joinpath(filename)
+    return resources.files(__package__) / subpackage_dir / filename
 
 
 def _get_filepath(
@@ -679,11 +679,7 @@ def _load_package_pickle_file(subpackage_dir: str, filename: str) -> Any:
 
     """
 
-    with (
-        resources.files(f"{__package__}.{subpackage_dir}")
-        .joinpath(filename)
-        .open("rb") as file
-    ):
+    with (resources.files(__package__) / subpackage_dir / filename).open("rb") as file:
         return pickle.load(file)
 
 


### PR DESCRIPTION


<!-- Thank you for contributing a Pull Request! Please ensure you also check the contributor guidelines:
https://github.com/radioactivedecay/radioactivedecay/blob/main/CONTRIBUTING.md -->

#### What does this PR implement/fix?

Issue was the same as the one seen here:
https://github.com/GNS3/gns3-server/issues/2147#issuecomment-1732281633

and the solution:
https://github.com/GNS3/gns3-server/pull/2290/files
is not to pass `a.b` to importlib.resources.files() as Python 3.9 cannot cope with this

#### Fixes Issue
#117 


#### Other comments?
