### PR TITLE
Fix documentation about examples on decay_time_series* functionalities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.X.X] - 202X-XX-XX
+- Fix issues in `Inventory.decay_time_series_pandas()` & `Inventory.decay_time_series()` doc
+strings (#119 thanks to @alberto743).
+
 ## [0.6.1] - 2025-01-09
 - Fix `TypeError: expected str, bytes or os.PathLike object, not NoneType` errors on import with
 Python 3.9 (#117 & #118)

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -250,6 +250,7 @@ Special thanks to:
 * `Christian Schreinemachers <https://github.com/Cs137>`_
 * `Sean Neutzmann <https://github.com/snuetzmann>`_
 * `@buresjan <https://github.com/buresjan>`_
+* `Alberto Previti <https://github.com/alberto743>`_
 
 for suggestions, support and assistance to this project.
 

--- a/radioactivedecay/inventory.py
+++ b/radioactivedecay/inventory.py
@@ -857,7 +857,7 @@ class AbstractInventory(ABC):
         Examples
         --------
         >>> inv = rd.Inventory({'C-14': 1.0})
-        >>> inv.decay_data_as_dataframe(time_period=10, time_units='ky', decay_units='mass_frac', npoints=4)
+        >>> inv.decay_time_series_pandas(time_period=10, time_units='ky', decay_units='mass_frac', npoints=4)
                        C-14      N-14
         Time (ky)
         0.000000   1.000000  0.000000
@@ -964,7 +964,7 @@ class AbstractInventory(ABC):
         Examples
         --------
         >>> inv = rd.Inventory({'C-14': 1.0})
-        >>> time, data = inv.decay_time_series_pandas(time_period=10, time_units="ky", decay_units="mass_frac", npoints=4)
+        >>> time, data = inv.decay_time_series(time_period=10, time_units="ky", decay_units="mass_frac", npoints=4)
         >>> time
         [0.0, 3.3333333333333335, 6.666666666666667, 10.0]
         >>> data


### PR DESCRIPTION
#### What does this PR implement/fix?
The documentation about the `decay_time_series` and `decay_time_series_pandas` methods of the `Inventory` class.

#### Fixes Issue
The names of the methods in the examples have been swapped.

#### Other comments?
No functionality change.